### PR TITLE
import Alert from the right place

### DIFF
--- a/src/views/common/SnackPack.tsx
+++ b/src/views/common/SnackPack.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {
+    Alert,
     AlertColor,
     IconButton,
     Snackbar,
@@ -10,7 +11,6 @@ import dispatcher from "../../data/dispatcher";
 import snackBarStore from "../../data/snackBarStore";
 import UiActions from "../../data/UiActions";
 import useFluxStore from "../../data/useFluxStore";
-import { Alert, } from "@mui/lab";
 
 const useStyles = makeStyles(theme => ({
     snackbar: {


### PR DESCRIPTION
The MUI Alert component was promoted from the lab in v5.
Change its import to the main material module, not the lab.