### PR TITLE
Scaling

### DIFF
--- a/src/containers/Recipe.js
+++ b/src/containers/Recipe.js
@@ -75,9 +75,12 @@ const Recipe = ({match}) => {
     );
 
     if (state.recipeLO.hasValue()) {
-        return <RecipeDetail {...state}
-                             canFavorite
-                             canShare />;
+        return <RecipeDetail
+            {...state}
+            canFavorite
+            canShare
+            canSendToPlan
+        />;
     }
 
     if (state.recipeLO.isLoading()) {

--- a/src/containers/Recipe.js
+++ b/src/containers/Recipe.js
@@ -6,6 +6,7 @@ import React from "react";
 import { Redirect } from "react-router-dom";
 import LoadObject from "util/LoadObject";
 import { useProfileLO } from "../providers/Profile";
+import { ScalingProvider } from "../util/ScalingContext";
 import LoadingIndicator from "../views/common/LoadingIndicator";
 import RecipeDetail from "../views/cook/RecipeDetail";
 
@@ -75,12 +76,14 @@ const Recipe = ({match}) => {
     );
 
     if (state.recipeLO.hasValue()) {
-        return <RecipeDetail
-            {...state}
-            canFavorite
-            canShare
-            canSendToPlan
-        />;
+        return <ScalingProvider>
+            <RecipeDetail
+                {...state}
+                canFavorite
+                canShare
+                canSendToPlan
+            />
+        </ScalingProvider>;
     }
 
     if (state.recipeLO.isLoading()) {

--- a/src/data/RecipeActions.js
+++ b/src/data/RecipeActions.js
@@ -10,6 +10,7 @@ const dissectionComponentType = PropTypes.shape({
 const sendToPlanShape = {
     recipeId: PropTypes.number.isRequired,
     planId: PropTypes.number.isRequired,
+    scale: PropTypes.number,
 };
 
 const RecipeActions = {

--- a/src/data/RecipeApi.js
+++ b/src/data/RecipeApi.js
@@ -1,9 +1,9 @@
 import BaseAxios from "axios";
-import {API_BASE_URL} from "../constants/index";
+import queryClient from "data/queryClient";
 import promiseFlux from "util/promiseFlux";
 import promiseWellSizedFile from "util/promiseWellSizedFile";
+import { API_BASE_URL } from "../constants/index";
 import RecipeActions from "./RecipeActions";
-import queryClient from "data/queryClient";
 
 const axios = BaseAxios.create({
     baseURL: `${API_BASE_URL}/api`,
@@ -81,10 +81,10 @@ const RecipeApi = {
             })
         );
     },
-    
-    sendToPlan(recipeId, planId) {
+
+    sendToPlan(recipeId, planId, scale) {
         promiseFlux(
-            axios.post(`/recipe/${recipeId}/_send_to_plan/${planId}`),
+            axios.post(`/recipe/${recipeId}/_send_to_plan/${planId}?scale=${scale || 1}`),
             () => ({
                 type: RecipeActions.SENT_TO_PLAN,
                 recipeId,
@@ -109,6 +109,7 @@ const RecipeApi = {
             }),
         );
     },
+
     addLabel(id, label) {
         promiseFlux(
             // this endpoint wants a plain-text post body containing the label

--- a/src/data/snackBarStore.js
+++ b/src/data/snackBarStore.js
@@ -1,16 +1,16 @@
-import {Button} from "@mui/material";
-import {ReduceStore} from "flux/utils";
+import { Button } from "@mui/material";
+import TaskActions from "features/Planner/data/TaskActions";
+import { willStatusDelete } from "features/Planner/data/TaskStatus";
+import TaskStore from "features/Planner/data/TaskStore";
+import LibraryStore from "features/RecipeLibrary/data/LibraryStore";
+import { ReduceStore } from "flux/utils";
 import PropTypes from "prop-types";
 import React from "react";
 import typedStore from "util/typedStore";
 import dispatcher from "./dispatcher";
-import LibraryStore from "features/RecipeLibrary/data/LibraryStore";
 import PantryItemActions from "./PantryItemActions";
 import RecipeActions from "./RecipeActions";
-import TaskActions from "features/Planner/data/TaskActions";
-import TaskStore from "features/Planner/data/TaskStore";
 import UiActions from "./UiActions";
-import {willStatusDelete} from "features/Planner/data/TaskStatus";
 
 const enqueue = (state, item) => {
     return {
@@ -100,11 +100,12 @@ class SnackBarStore extends ReduceStore {
             case RecipeActions.SENT_TO_PLAN: {
                 const plan = TaskStore.getTaskLO(action.planId)
                     .getValueEnforcing();
+                // if came from the library, the store might not have it...
                 const recipe = LibraryStore.getIngredientById(action.recipeId)
-                    .getValueEnforcing();
+                    .getValue();
                 return enqueue(state, {
-                    message: `Added ${recipe.name} to ${plan.name}`,
-                    severity: "success"
+                    message: `Added ${recipe ? recipe.name : "recipe"} to ${plan.name}`,
+                    severity: "success",
                 });
             }
 

--- a/src/features/RecipeLibrary/components/LabelItem.tsx
+++ b/src/features/RecipeLibrary/components/LabelItem.tsx
@@ -1,6 +1,5 @@
-import {Chip} from "@mui/material";
+import { Chip } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
-import PropTypes from "prop-types";
 import React from "react";
 
 const useStyles = makeStyles((theme) => ({
@@ -9,17 +8,17 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-const LabelItem = ({label}) => {
+interface Props {
+    label: string
+}
+
+const LabelItem: React.FC<Props> = ({ label }) => {
     const classes = useStyles();
     return <Chip
         size="small"
         label={label}
         className={classes.root}
     />;
-};
-
-LabelItem.propTypes = {
-    label: PropTypes.string
 };
 
 export default LabelItem;

--- a/src/features/RecipeLibrary/components/RecipeCard.tsx
+++ b/src/features/RecipeLibrary/components/RecipeCard.tsx
@@ -163,7 +163,7 @@ const RecipeCard: React.FC<Props> = ({
                     </Button>
                     <SendToPlan onClick={planId => Dispatcher.dispatch({
                         type: RecipeActions.SEND_TO_PLAN,
-                        recipeId: recipe.id,
+                        recipeId: parseInt(recipe.id),
                         planId,
                     })} />
                 </Stack>

--- a/src/features/RecipeLibrary/components/SendToPlan.tsx
+++ b/src/features/RecipeLibrary/components/SendToPlan.tsx
@@ -1,9 +1,14 @@
-import {Button, IconButton,} from "@mui/material";
+import {
+    Button,
+    IconButton,
+} from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
-import {AddShoppingCart, ExitToApp,} from "@mui/icons-material";
+import {
+    AddShoppingCart,
+    ExitToApp,
+} from "@mui/icons-material";
 import React from "react";
 import useActivePlannerLO from "data/useActivePlannerLO";
-import PropTypes from "prop-types";
 
 const useStyles = makeStyles({
     button: {
@@ -13,7 +18,12 @@ const useStyles = makeStyles({
     },
 });
 
-const SendToPlan = ({onClick, iconOnly}) => {
+interface Props {
+    onClick: (number) => void
+    iconOnly?: boolean
+}
+
+const SendToPlan: React.FC<Props> = ({ onClick, iconOnly }) => {
     const classes = useStyles();
     const listLO = useActivePlannerLO();
     if (!listLO.hasValue()) return null;
@@ -44,11 +54,6 @@ const SendToPlan = ({onClick, iconOnly}) => {
             </span>
         </Button>;
     }
-};
-
-SendToPlan.propTypes = {
-    onClick: PropTypes.func.isRequired,
-    iconOnly: PropTypes.bool,
 };
 
 export default SendToPlan;

--- a/src/features/RecipeLibrary/data/LibraryStore.js
+++ b/src/features/RecipeLibrary/data/LibraryStore.js
@@ -10,7 +10,7 @@ import { clientOrDatabaseIdType } from "util/ClientId";
 import history from "util/history";
 import LoadObject from "util/LoadObject";
 import LoadObjectMap from "util/LoadObjectMap";
-import { loadObjectMapOf, } from "util/loadObjectTypes";
+import { loadObjectMapOf } from "util/loadObjectTypes";
 import { fromMilliseconds } from "util/time";
 import typedStore from "util/typedStore";
 import LibraryActions from "./LibraryActions";
@@ -128,6 +128,7 @@ class LibraryStore extends ReduceStore {
                 RecipeApi.sendToPlan(
                     action.recipeId,
                     action.planId,
+                    action.scale,
                 );
                 return state;
             }

--- a/src/global/types/types.ts
+++ b/src/global/types/types.ts
@@ -1,25 +1,36 @@
 /**
  * Adding some utility types here for poorly types MUI enums
  */
-export type MUISize =  "medium" | "small" | undefined
+export type MUISize = "medium" | "small" | undefined
 
 export type Optional<Type> = Type | null | undefined
 
 export type OptionalNumberish = number | string | undefined
 
+export interface UserType {
+    email: string,
+    imageUrl?: string,
+}
+
 export type Ingredient = {
     id: number,
     name: string,
+    type?: "Recipe" | "PantryItem"
 }
 
 export type IngredientRef = {
-    raw: string,
+    raw?: string,
     quantity?: number,
     preparation?: string,
     units?: string,
     uomId?: string | number;
     ingredient?: string | Ingredient,
     ingredientId?: number,
+
+    /**
+     * On the shopping list, napalm entries will only have name, not raw.
+     */
+    name?: string
 };
 
 export type Recipe = {
@@ -28,6 +39,7 @@ export type Recipe = {
     name: string,
     externalUrl: string,
     ingredients: IngredientRef[],
+    labels: string[],
     directions: string,
     yield: number,
     totalTime: number,
@@ -44,9 +56,12 @@ export type SharedRecipe = {
 
 export type Plan = any
 
-export type LoadObject<T> = {
-    value: T,
-    hasValue: () => boolean,
-    isLoading: () => boolean
-    getValueEnforcing: () => T
+export interface LoadObject<T> {
+    getValue(): Optional<T>
+
+    hasValue(): boolean
+
+    isLoading(): boolean
+
+    getValueEnforcing(): T
 }

--- a/src/util/ScalingContext.tsx
+++ b/src/util/ScalingContext.tsx
@@ -1,0 +1,87 @@
+import React, {
+    createContext,
+    PropsWithChildren,
+    useContext,
+    useState,
+} from "react";
+import { Maybe } from "graphql/jsutils/Maybe";
+
+interface Option {
+    label: string
+    value: number
+    active: boolean
+
+    select(): void
+}
+
+const OPTIONS = [
+    { label: "¼", value: 0.25 },
+    { label: "½", value: 0.5 },
+    { label: "1", value: 1 },
+    { label: "2", value: 2 },
+];
+
+const ScaleContext = createContext<number>(1);
+
+const SetScaleContext = createContext<Maybe<(Option) => void>>(null);
+
+/**
+ * Creates a new scaling context, initially scaled to 1 (no scaling).
+ */
+export const ScalingProvider: React.FC<PropsWithChildren> = ({
+                                                                 children,
+                                                             }) => {
+    const [ scale, setScale ] = useState(1);
+    return <ScaleContext.Provider value={scale}>
+        <SetScaleContext.Provider value={setScale}>
+            {children}
+        </SetScaleContext.Provider>
+    </ScaleContext.Provider>;
+};
+
+/**
+ * If a scaling context is already open, do nothing. Otherwise, create a new one
+ * as if ScalingProvider had been called.
+ */
+export const ReentrantScalingProvider: React.FC<PropsWithChildren> = ({
+                                                                          children,
+                                                                      }) => {
+    const ctx = useContext(SetScaleContext);
+    return ctx == null
+        ? <ScalingProvider>
+            {children}
+        </ScalingProvider>
+        : <>
+            {children}
+        </>;
+};
+
+/**
+ * Returns the current context's scaling factor, or 1 (no scaling) if outside a
+ * scaling context.
+ */
+export const useScale = () =>
+    useContext(ScaleContext);
+
+export const useScaleOptions = () => {
+    let found = false;
+    const value = useScale();
+    const set = useContext(SetScaleContext);
+    if (set == null) {
+        throw new TypeError("useScaleOptions must be used w/in a scaling context.");
+    }
+    const opts = OPTIONS.map(it => {
+        if (it.value === value) {
+            found = true;
+            return { ...it, active: true };
+        } else {
+            return { ...it, active: false };
+        }
+    });
+    if (!found) {
+        opts.push({ value, label: "" + value, active: true });
+    }
+    // @ts-ignore
+    opts.forEach(it => it.select = () => set(it.value));
+    return opts as Option[];
+};

--- a/src/views/IngredientItem.tsx
+++ b/src/views/IngredientItem.tsx
@@ -12,6 +12,7 @@ import history from "util/history";
 import Quantity from "views/common/Quantity";
 import SendToPlan from "features/RecipeLibrary/components/SendToPlan";
 import { IngredientRef } from "../global/types/types";
+import { useScale } from "../util/ScalingContext";
 
 const useStyles = makeStyles(() => ({
     quantity: {
@@ -45,13 +46,19 @@ interface Props {
     inline?: boolean
 }
 
-const IngredientItem: React.FC<Props> = ({ ingRef: ref, hideRecipeLink, hideSendToPlan, inline }) => {
+const IngredientItem: React.FC<Props> = ({
+                                             ingRef: ref,
+                                             hideRecipeLink,
+                                             hideSendToPlan,
+                                             inline,
+                                         }) => {
     const classes = useStyles();
+    const scale = useScale();
 
     let left, right;
     if (ref.quantity != null) {
         left = <Quantity
-            quantity={ref.quantity}
+            quantity={ref.quantity * scale}
             units={ref.units}
         />;
     }

--- a/src/views/IngredientItem.tsx
+++ b/src/views/IngredientItem.tsx
@@ -11,6 +11,7 @@ import TaskActions from "features/Planner/data/TaskActions";
 import history from "util/history";
 import Quantity from "views/common/Quantity";
 import SendToPlan from "features/RecipeLibrary/components/SendToPlan";
+import { IngredientRef } from "../global/types/types";
 
 const useStyles = makeStyles(() => ({
     quantity: {
@@ -36,26 +37,6 @@ const Augment: React.FC<AugmentProps> = ({
                                          }) => text
     ? <>{prefix}{text}{suffix}</>
     : null;
-
-export interface Ingredient {
-    type: "Recipe" | "PantryItem"
-    name: string
-    id: string | number
-}
-
-export interface IngredientRef {
-    /**
-     * You might think this is required, but when shopping, a ref might be to
-     * a napalm entry, and thus only have a name.
-     */
-    raw?: string
-    quantity?: number
-    units?: string
-    name?: string
-    preparation?: string
-    ingredient?: string | Ingredient
-    ingredientId?: string | number
-}
 
 interface Props {
     ingRef: IngredientRef

--- a/src/views/common/Quantity.tsx
+++ b/src/views/common/Quantity.tsx
@@ -1,34 +1,61 @@
-import PropTypes from "prop-types";
 import React from "react";
 
-function format(quantity) {
-    if (quantity === 0.25) return "1/4";
-    else if (quantity > 0.33 && quantity < 0.34) return "1/3";
-    else if (quantity === 0.5) return "1/2";
-    else if (quantity > 0.66 && quantity < 0.67) return "2/3";
-    else if (quantity === 0.75) return "3/4";
-    return quantity;
+function toVulgarFraction(quantity) {
+    if (quantity === 0.125) return "⅛";
+    else if (quantity === 0.25) return "¼";
+    else if (quantity >= 0.33 && quantity < 0.34) return "⅓";
+    else if (quantity === 0.375) return "⅜";
+    else if (quantity === 0.5) return "½";
+    else if (quantity === 0.625) return "⅝";
+    else if (quantity >= 0.66 && quantity < 0.67) return "⅔";
+    else if (quantity === 0.75) return "¾";
+    else if (quantity === 0.875) return "⅞";
 }
 
-const Quantity = ({quantity, units, addSpace}) => {
+const numberFormat = new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: 3,
+});
+
+export function toNumericString(quantity) {
+    if (quantity < 0) {
+        return "-" + toNumericString(Math.abs(quantity));
+    }
+    const whole = Math.floor(quantity);
+    if (quantity !== whole) {
+        const fraction = Math.abs(quantity - whole);
+        const vulgar = toVulgarFraction(fraction);
+        if (vulgar) {
+            return whole === 0
+                ? vulgar
+                : whole + vulgar;
+        }
+    }
+    return numberFormat.format(quantity);
+}
+
+interface Props {
+    quantity: number
+    units?: string // for the moment, at least
+    addSpace?: boolean
+}
+
+const Quantity: React.FC<Props> = ({
+                                       quantity,
+                                       units,
+                                       addSpace,
+                                   }) => {
     if (quantity == null) return null;
     return units == null
         ? <React.Fragment>
-            {format(quantity)}
+            {toNumericString(quantity)}
             {addSpace && " "}
         </React.Fragment>
         : <React.Fragment>
-            {format(quantity)}
+            {toNumericString(quantity)}
             {" "}
             {units}
             {addSpace && " "}
         </React.Fragment>;
-};
-
-Quantity.propTypes = {
-    quantity: PropTypes.number,
-    units: PropTypes.string, // for the moment, at least
-    addSpace: PropTypes.bool,
 };
 
 export default Quantity;

--- a/src/views/common/SplitButton.tsx
+++ b/src/views/common/SplitButton.tsx
@@ -9,8 +9,7 @@ import Paper from "@mui/material/Paper";
 import Popper from "@mui/material/Popper";
 import { makeStyles } from "@mui/styles";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
-import PropTypes from "prop-types";
-import React from "react";
+import React, { ReactNode } from "react";
 
 const useStyles = makeStyles({
     popper: {
@@ -18,19 +17,32 @@ const useStyles = makeStyles({
     },
 });
 
-const SplitButton = props => {
-    const {
-        primary,
-        onClick,
-        onSelect,
-        options,
-        disabled,
-        dropdownDisabled = disabled,
-    } = props;
+interface Option {
+    id: string | number
+    label: string
+}
+
+interface Props {
+    primary: ReactNode
+    onClick: (MouseEvent) => void
+    options: Option[]
+    onSelect: (event, Option) => void
+    disabled?: boolean
+    dropdownDisabled?: boolean
+}
+
+const SplitButton: React.FC<Props> = ({
+                                          primary,
+                                          onClick,
+                                          onSelect,
+                                          options,
+                                          disabled = false,
+                                          dropdownDisabled = disabled,
+                                      }) => {
     const classes = useStyles();
-    const [open, setOpen] = React.useState(false);
+    const [ open, setOpen ] = React.useState(false);
     const anchorRef = React.useRef<HTMLDivElement>(null);
-    const [selectedOption, setSelectedOption] = React.useState(null);
+    const [ selectedOption, setSelectedOption ] = React.useState(null);
 
     const handleClick = (event) => {
         onClick && onClick(event);
@@ -113,18 +125,6 @@ const SplitButton = props => {
             </Grid>
         </Grid>
     );
-};
-
-SplitButton.propTypes = {
-    primary: PropTypes.node.isRequired,
-    onClick: PropTypes.func.isRequired,
-    options: PropTypes.arrayOf(PropTypes.shape({
-        id: PropTypes.any.isRequired,
-        label: PropTypes.string.isRequired,
-    })),
-    onSelect: PropTypes.func.isRequired,
-    disabled: PropTypes.bool,
-    dropdownDisabled: PropTypes.bool,
 };
 
 export default SplitButton;

--- a/src/views/cook/IngredientDirectionsRow.tsx
+++ b/src/views/cook/IngredientDirectionsRow.tsx
@@ -1,4 +1,6 @@
 import {
+    Button,
+    ButtonGroup,
     Grid,
     List,
     ListItem,
@@ -8,6 +10,7 @@ import React from "react";
 import Directions from "../common/Directions";
 import IngredientItem from "../IngredientItem";
 import { Recipe } from "../../global/types/types";
+import { useScaleOptions } from "../../util/ScalingContext";
 
 interface Props {
     recipe: Recipe,
@@ -15,31 +18,59 @@ interface Props {
     hideHeadings?: boolean,
 }
 
-const IngredientDirectionsRow: React.FC<Props> = ({ recipe, loggedIn, hideHeadings }) => <>
-    <Grid item xs={12} sm={5}>
-        {recipe.ingredients && recipe.ingredients.length > 0 && <>
-            {!hideHeadings && <Typography variant="h5">
-                Ingredients
-            </Typography>}
-            <List>
-                {recipe.ingredients.map((it, i) =>
-                    <ListItem key={i}>
-                        <IngredientItem
-                            ingRef={it}
-                            hideRecipeLink={!loggedIn}
-                            hideSendToPlan={!loggedIn}
-                        />
-                    </ListItem>)}
-            </List>
-        </>}
-    </Grid>
+const IngredientDirectionsRow: React.FC<Props> = ({
+                                                      recipe,
+                                                      loggedIn,
+                                                      hideHeadings,
+                                                  }) => {
+    const scaleOpts = useScaleOptions();
+    return <>
+        <Grid item xs={12} sm={5}>
+            {recipe.ingredients && recipe.ingredients.length > 0 && <>
+                {!hideHeadings && <Grid container justifyContent={"space-between"}>
+                    <Typography variant="h5">
+                        Ingredients
+                    </Typography>
+                    <ButtonGroup
+                        size="small"
+                        variant="text"
+                        color={"inherit"}
+                    >
+                        {scaleOpts.map(opt => {
+                            return <Button
+                                key={opt.value}
+                                onClick={e => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    opt.select();
+                                }}
+                                variant={opt.active ? "contained" : undefined}
+                            >
+                                {opt.label}
+                            </Button>;
+                        })}
+                    </ButtonGroup>
+                </Grid>}
+                <List>
+                    {recipe.ingredients.map((it, i) =>
+                        <ListItem key={i}>
+                            <IngredientItem
+                                ingRef={it}
+                                hideRecipeLink={!loggedIn}
+                                hideSendToPlan={!loggedIn}
+                            />
+                        </ListItem>)}
+                </List>
+            </>}
+        </Grid>
 
-    <Grid item xs={12} sm={7}>
-        {recipe.directions && <React.Fragment>
-            {!hideHeadings && <Typography variant="h5">Directions</Typography>}
-            <Directions text={recipe.directions} />
-        </React.Fragment>}
-    </Grid>
-</>;
+        <Grid item xs={12} sm={7}>
+            {recipe.directions && <React.Fragment>
+                {!hideHeadings && <Typography variant="h5">Directions</Typography>}
+                <Directions text={recipe.directions} />
+            </React.Fragment>}
+        </Grid>
+    </>;
+};
 
 export default IngredientDirectionsRow;

--- a/src/views/cook/IngredientDirectionsRow.tsx
+++ b/src/views/cook/IngredientDirectionsRow.tsx
@@ -6,12 +6,8 @@ import {
 } from "@mui/material";
 import React from "react";
 import Directions from "../common/Directions";
-import IngredientItem, { IngredientRef } from "../IngredientItem";
-
-interface Recipe {
-    ingredients: IngredientRef[],
-    directions?: string,
-}
+import IngredientItem from "../IngredientItem";
+import { Recipe } from "../../global/types/types";
 
 interface Props {
     recipe: Recipe,

--- a/src/views/cook/RecipeDetail.tsx
+++ b/src/views/cook/RecipeDetail.tsx
@@ -1,16 +1,23 @@
-import {Box, CircularProgress, Grid, Toolbar, Typography, useScrollTrigger,} from "@mui/material";
+import {
+    Box,
+    CircularProgress,
+    Grid,
+    Toolbar,
+    Typography,
+    useScrollTrigger,
+} from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
-import {PostAdd} from "@mui/icons-material";
+import { PostAdd } from "@mui/icons-material";
 import PropTypes from "prop-types";
 import React from "react";
 import Dispatcher from "../../data/dispatcher";
 import RecipeActions from "../../data/RecipeActions";
 import RecipeApi from "../../data/RecipeApi";
-import {Recipe} from "../../data/RecipeTypes";
+import { Recipe } from "../../data/RecipeTypes";
 import useWindowSize from "../../data/useWindowSize";
 import history from "../../util/history";
-import {loadObjectOf} from "../../util/loadObjectTypes";
-import {formatDuration} from "../../util/time";
+import { loadObjectOf } from "../../util/loadObjectTypes";
+import { formatDuration } from "../../util/time";
 import CloseButton from "../common/CloseButton";
 import CopyButton from "../common/CopyButton";
 import DeleteButton from "../common/DeleteButton";
@@ -27,7 +34,7 @@ import IngredientDirectionsRow from "./IngredientDirectionsRow";
 import ShareRecipe from "./ShareRecipe";
 import SubrecipeItem from "./SubrecipeItem";
 import SendToPlan from "features/RecipeLibrary/components/SendToPlan";
-import {OptionalNumberish} from "global/types/types";
+import { OptionalNumberish } from "global/types/types";
 import FavoriteIndicator from "../../features/Favorites/components/Indicator";
 
 const useStyles = makeStyles(theme => ({
@@ -106,16 +113,25 @@ function extractRecipePhoto(recipe: any) { // todo: remove
     }
 }
 
-const RecipeDetail = ({recipeLO, subrecipes, mine, ownerLO, anonymous, canFavorite, canShare}) => {
-
+const RecipeDetail = ({
+                          recipeLO,
+                          subrecipes,
+                          mine,
+                          ownerLO,
+                          anonymous,
+                          canFavorite,
+                          canShare,
+                          canSendToPlan,
+                      }) => {
     const classes = useStyles();
 
     const windowSize = useWindowSize();
 
-    let loggedIn = true;
-    if (anonymous) {
+    const loggedIn = !anonymous;
+    if (anonymous && mine) {
+        // eslint-disable-next-line no-console
+        console.warn("Viewer is anonymous, but thinks they own the recipe?!");
         mine = false;
-        loggedIn = false;
     }
 
     const recipe = recipeLO.getValueEnforcing();
@@ -192,8 +208,7 @@ const RecipeDetail = ({recipeLO, subrecipes, mine, ownerLO, anonymous, canFavori
                             <LabelItem key={label} label={label} />)}
                     </Box>}
 
-                    {/* todo: this does a store hit for the plan, and only makes sense for a library recipe */}
-                    {loggedIn && <Box mt={1}>
+                    {loggedIn && canSendToPlan && <Box mt={1}>
                         <SendToPlan
                             onClick={planId => Dispatcher.dispatch({
                                 type: RecipeActions.SEND_TO_PLAN,
@@ -236,6 +251,7 @@ RecipeDetail.propTypes = {
     ownerLO: loadObjectOf(PropTypes.object).isRequired,
     canFavorite: PropTypes.bool,
     canShare: PropTypes.bool,
+    canSendToPlan: PropTypes.bool,
 };
 
 export default RecipeDetail;

--- a/src/views/cook/RecipeDetail.tsx
+++ b/src/views/cook/RecipeDetail.tsx
@@ -8,15 +8,12 @@ import {
 } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
 import { PostAdd } from "@mui/icons-material";
-import PropTypes from "prop-types";
-import React from "react";
+import React, { PropsWithChildren } from "react";
 import Dispatcher from "../../data/dispatcher";
 import RecipeActions from "../../data/RecipeActions";
 import RecipeApi from "../../data/RecipeApi";
-import { Recipe } from "../../data/RecipeTypes";
 import useWindowSize from "../../data/useWindowSize";
 import history from "../../util/history";
-import { loadObjectOf } from "../../util/loadObjectTypes";
 import { formatDuration } from "../../util/time";
 import CloseButton from "../common/CloseButton";
 import CopyButton from "../common/CopyButton";
@@ -34,7 +31,12 @@ import IngredientDirectionsRow from "./IngredientDirectionsRow";
 import ShareRecipe from "./ShareRecipe";
 import SubrecipeItem from "./SubrecipeItem";
 import SendToPlan from "features/RecipeLibrary/components/SendToPlan";
-import { OptionalNumberish } from "global/types/types";
+import {
+    LoadObject,
+    OptionalNumberish,
+    Recipe,
+    UserType,
+} from "global/types/types";
 import FavoriteIndicator from "../../features/Favorites/components/Indicator";
 
 const useStyles = makeStyles(theme => ({
@@ -59,15 +61,15 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
-const SubHeader = ({children}) => {
+const SubHeader: React.FC<PropsWithChildren> = ({ children }) => {
     const windowSize = useWindowSize();
-    const [height, setHeight] = React.useState<OptionalNumberish>("auto");
-    const [width, setWidth] = React.useState<OptionalNumberish>("auto");
+    const [ height, setHeight ] = React.useState<OptionalNumberish>("auto");
+    const [ width, setWidth ] = React.useState<OptionalNumberish>("auto");
     const inner = React.useRef<HTMLDivElement>();
     React.useLayoutEffect(() => {
         setHeight(inner?.current?.clientHeight);
         setWidth((inner?.current?.parentNode as HTMLElement).clientWidth);
-    }, [windowSize.width]);
+    }, [ windowSize.width ]);
     const trigger = useScrollTrigger({
         disableHysteresis: true,
         // roughly the spacing 2
@@ -95,10 +97,6 @@ const SubHeader = ({children}) => {
     </div>;
 };
 
-SubHeader.propTypes = {
-    children: PropTypes.node.isRequired,
-};
-
 function extractRecipePhoto(recipe: any) { // todo: remove
     if (!recipe || !recipe.photo) return null;
     if (typeof recipe.photo === "string") {
@@ -113,16 +111,27 @@ function extractRecipePhoto(recipe: any) { // todo: remove
     }
 }
 
-const RecipeDetail = ({
-                          recipeLO,
-                          subrecipes,
-                          mine,
-                          ownerLO,
-                          anonymous,
-                          canFavorite,
-                          canShare,
-                          canSendToPlan,
-                      }) => {
+interface Props {
+    recipeLO: LoadObject<Recipe>
+    subrecipes?: Recipe[]
+    anonymous?: boolean,
+    mine?: boolean,
+    ownerLO: LoadObject<UserType>
+    canFavorite?: boolean,
+    canShare?: boolean,
+    canSendToPlan?: boolean,
+}
+
+const RecipeDetail: React.FC<Props> = ({
+                                           recipeLO,
+                                           subrecipes,
+                                           mine = false,
+                                           ownerLO,
+                                           anonymous = false,
+                                           canFavorite = false,
+                                           canShare = false,
+                                           canSendToPlan = false,
+                                       }) => {
     const classes = useStyles();
 
     const windowSize = useWindowSize();
@@ -239,19 +248,6 @@ const RecipeDetail = ({
             </FoodingerFab>}
         </PageBody>
     );
-};
-
-RecipeDetail.propTypes = {
-    // @ts-ignore
-    recipeLO: loadObjectOf(Recipe).isRequired,
-    subrecipes: PropTypes.arrayOf(Recipe),
-    anonymous: PropTypes.bool,
-    mine: PropTypes.bool,
-    // @ts-ignore
-    ownerLO: loadObjectOf(PropTypes.object).isRequired,
-    canFavorite: PropTypes.bool,
-    canShare: PropTypes.bool,
-    canSendToPlan: PropTypes.bool,
 };
 
 export default RecipeDetail;

--- a/src/views/cook/RecipeDetail.tsx
+++ b/src/views/cook/RecipeDetail.tsx
@@ -38,6 +38,10 @@ import {
     UserType,
 } from "global/types/types";
 import FavoriteIndicator from "../../features/Favorites/components/Indicator";
+import {
+    ReentrantScalingProvider,
+    useScale,
+} from "../../util/ScalingContext";
 
 const useStyles = makeStyles(theme => ({
     name: {
@@ -135,6 +139,7 @@ const RecipeDetail: React.FC<Props> = ({
     const classes = useStyles();
 
     const windowSize = useWindowSize();
+    const scale = useScale();
 
     const loggedIn = !anonymous;
     if (anonymous && mine) {
@@ -223,6 +228,7 @@ const RecipeDetail: React.FC<Props> = ({
                                 type: RecipeActions.SEND_TO_PLAN,
                                 recipeId: recipe.id,
                                 planId,
+                                scale,
                             })}
                         />
                     </Box>}
@@ -235,11 +241,12 @@ const RecipeDetail: React.FC<Props> = ({
                         loggedIn={loggedIn}
                     />)}
 
-                <IngredientDirectionsRow
-                    recipe={recipe}
-                    loggedIn={loggedIn}
-                />
-
+                <ReentrantScalingProvider>
+                    <IngredientDirectionsRow
+                        recipe={recipe}
+                        loggedIn={loggedIn}
+                    />
+                </ReentrantScalingProvider>
             </Grid>
             {loggedIn && <FoodingerFab
                 onClick={() => history.push(`/add`)}

--- a/src/views/cook/SharedRecipe.tsx
+++ b/src/views/cook/SharedRecipe.tsx
@@ -9,6 +9,10 @@ import LoadObject from "../../util/LoadObject";
 import LoadingIndicator from "../common/LoadingIndicator";
 import RecipeDetail from "./RecipeDetail";
 import LibraryActions from "features/RecipeLibrary/data/LibraryActions";
+import {
+    Optional,
+    UserType,
+} from "../../global/types/types";
 
 const axios = BaseAxios.create({
     baseURL: `${API_BASE_URL}/shared/recipe`,
@@ -20,7 +24,7 @@ const DoTheDance = props => {
         secret,
         id,
     } = props;
-    const [owner, setOwner] = React.useState(null);
+    const [ owner, setOwner ] = React.useState<Optional<UserType>>(undefined);
     React.useEffect(() => {
         axios.get(`/${slug}/${secret}/${id}.json`)
             .then(

--- a/src/views/cook/SubrecipeItem.tsx
+++ b/src/views/cook/SubrecipeItem.tsx
@@ -10,6 +10,7 @@ import { Recipe } from "../../data/RecipeTypes";
 import { formatDuration } from "util/time";
 import CollapseIconButton from "global/components/CollapseIconButton";
 import IngredientDirectionsRow from "./IngredientDirectionsRow";
+import { ScalingProvider } from "../../util/ScalingContext";
 
 const useStyles = makeStyles({
     time: {
@@ -47,11 +48,14 @@ const SubrecipeItem = ({recipe, loggedIn}) => {
             </Typography>
         </Grid>
         {expanded && <>
-            <IngredientDirectionsRow
-                loggedIn={loggedIn}
-                recipe={recipe}
-                hideHeadings
-            />
+            {/* Subrecipes do not scale w/ the main recipe */}
+            <ScalingProvider>
+                <IngredientDirectionsRow
+                    loggedIn={loggedIn}
+                    recipe={recipe}
+                    hideHeadings
+                />
+            </ScalingProvider>
             <Grid item xs={12}>
                 <Divider
                     variant={"middle"}

--- a/src/views/pantry/formatQuantity.js
+++ b/src/views/pantry/formatQuantity.js
@@ -1,38 +1,4 @@
-function toNumericString(quantity) {
-    if (quantity < 0) {
-        return "-" + toNumericString(Math.abs(quantity));
-    }
-    if (quantity > 1) {
-        const int = Math.trunc(quantity);
-        const dec = quantity - int;
-        if (dec === 0) {
-            return int.toString();
-        } else {
-            const decStr = toNumericString(dec);
-            if (decStr.startsWith("0.")) {
-                return `${int}${decStr.substr(1)}`;
-            } else {
-                return `${int} & ${decStr}`;
-            }
-        }
-    }
-    if (quantity === 0.25) {
-        return "1/4";
-    } else if (quantity > 0.33 && quantity < 0.34) {
-        return "1/3";
-    } else if (quantity === 0.5) {
-        return "1/2";
-    } else if (quantity > 0.66 && quantity < 0.67) {
-        return "2/3";
-    } else if (quantity === 0.75) return "3/4";
-    const s = quantity.toString();
-    const len = s.length;
-    const precision = s.replace(/^[0.]+/, "").length;
-    if (precision <= len - 3) {
-        return s;
-    }
-    return s.substr(0, len - precision + 3);
-}
+import { toNumericString } from "../common/Quantity";
 
 export function formatQuantity(q) {
     // is it compound quantity?


### PR DESCRIPTION
On recipe detail pages offer ephemeral scaling (quarter, half, whole, double) of ingredients, and use the scaling factor when sending recipes from the library to the plan. You always get "no scaling" from the cards on search results. Subrecipes do not participate in the scaling, as there's not currently a quantified association between them and the main/parent recipe to multiply across.