### PR TITLE
nav tweaks for beta

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,10 +29,12 @@ function App() {
         <StyledEngineProvider injectFirst>
             <ThemeProvider theme={theme}>
                 <CssBaseline/>
-                {authenticated && newVersionAvailable && <NewVersionAvailable/>}
                 <NavigationController
                     authenticated={authenticated}
                 >
+                    {authenticated
+                        && newVersionAvailable
+                        && <NewVersionAvailable />}
                     <RoutingSwitch
                         routes={routes}
                         authenticated={authenticated}

--- a/src/features/Navigation/NavigationController.tsx
+++ b/src/features/Navigation/NavigationController.tsx
@@ -1,5 +1,8 @@
 import * as React from "react";
-import { ReactNode } from "react";
+import {
+    ReactNode,
+    useEffect
+} from "react";
 import CssBaseline from "@mui/material/CssBaseline";
 import {
     Header,
@@ -18,6 +21,7 @@ import { useHistory } from "react-router-dom";
 import { useLogoutHandler } from "providers/Profile";
 import Dispatcher from "data/dispatcher";
 import PlanActions from "features/Planner/data/PlanActions";
+import RouteStore from "../../data/RouteStore";
 
 type NavigationControllerProps = {
     authenticated: boolean,
@@ -29,6 +33,16 @@ export const NavigationController: React.FC<NavigationControllerProps> = ({authe
     const isMobile = useIsMobile();
     const devMode = useIsDevMode();
     const history = useHistory();
+    const [ selected, setSelected ] = React.useState("");
+
+    const path = useFluxStore(() => {
+            const state = RouteStore.getState();
+            return state ? state.path : "/library";
+        },
+        [ RouteStore ]);
+    useEffect(() => {
+        setSelected(path.split("/")[1]);
+    }, [ path ]);
 
     const handleProfile = e => {
         e.stopPropagation();
@@ -70,6 +84,7 @@ export const NavigationController: React.FC<NavigationControllerProps> = ({authe
         return (<MainMobile>
             <Header elevation={0}/>
             <MobileNav
+                selected={selected}
                 handleProfile={handleProfile}
                 handleLogout={handleLogout}
             />
@@ -82,6 +97,7 @@ export const NavigationController: React.FC<NavigationControllerProps> = ({authe
             <CssBaseline/>
             <Header elevation={0}/>
             <DesktopNav
+                selected={selected}
                 expanded={expanded}
                 handleProfile={handleProfile}
                 handleLogout={handleLogout}

--- a/src/features/Navigation/components/DesktopNav.tsx
+++ b/src/features/Navigation/components/DesktopNav.tsx
@@ -91,6 +91,7 @@ export const DesktopNav: React.FC<DesktopNavProps> = ({
                 <Navigation>
                     {planItems && planItems.map(item => (
                         <NavPlanItem
+                            key={item.id}
                             id={item.id}
                             onSelect={handleSelectPlan}
                             expanded={expanded}

--- a/src/features/Navigation/components/DesktopNav.tsx
+++ b/src/features/Navigation/components/DesktopNav.tsx
@@ -27,6 +27,7 @@ import { colorHash } from "constants/colors";
 import Typography from "@mui/material/Typography";
 
 type DesktopNavProps = {
+    selected: string,
     planItems: any,
     handleProfile: (e: React.SyntheticEvent) => void,
     handleLogout: (e: React.SyntheticEvent) => void,
@@ -37,6 +38,7 @@ type DesktopNavProps = {
 }
 
 export const DesktopNav: React.FC<DesktopNavProps> = ({
+                                                          selected,
     planItems,
     handleExpand,
     handleProfile,
@@ -58,24 +60,28 @@ export const DesktopNav: React.FC<DesktopNavProps> = ({
                         value="library"
                         icon={<LibraryIcon />}
                         title="Library"
+                        selected={selected === "library"}
                     />
                     <NavItem
                         to="/plan"
                         value="plan"
                         icon={<PlanIcon />}
                         title="Plan"
+                        selected={selected === "plan"}
                     />
                     <NavItem
                         to="/shop"
                         value="shop"
                         icon={<ShopIcon />}
                         title="Shop"
+                        selected={selected === "shop"}
                     />
                     {devMode && <NavItem
                         to="/pantry"
                         value="pantry"
                         icon={<PantryIcon />}
                         title="Pantry"
+                        selected={selected === "pantry"}
                     />}
                     {/*<NavItem*/}
                     {/*    to="/timers"*/}
@@ -103,7 +109,8 @@ export const DesktopNav: React.FC<DesktopNavProps> = ({
             </Box>
             <Box sx={{alignItem: "bottom"}}>
                 <List>
-                    <ListItemButton onClick={handleProfile}>
+                    <ListItemButton onClick={handleProfile}
+                                    selected={selected === "profile"}>
                         <ListItemIcon>
                             <ProfileIcon/>
                         </ListItemIcon>

--- a/src/features/Navigation/components/MobileNav.tsx
+++ b/src/features/Navigation/components/MobileNav.tsx
@@ -23,22 +23,20 @@ const NavWrapper = styled(Paper)(({theme}) => ({
 }));
 
 type MobileNavProps = {
+    selected: string
     handleProfile: (e: React.SyntheticEvent) => void,
     handleLogout: (e: React.SyntheticEvent) => void,
 }
 
-export const MobileNav : React.FC<MobileNavProps> = ({handleProfile}) => {
-    const [ selected, setSelected ] = React.useState("library");
-    const onChange = (_, newValue) => {
-        setSelected(newValue);
-    };
-
+export const MobileNav: React.FC<MobileNavProps> = ({
+                                                        selected,
+                                                        handleProfile,
+                                                    }) => {
     return (
         <NavWrapper elevation={3}>
             <BottomNavigation
                 showLabels
                 value={selected}
-                onChange={onChange}
             >
                 <MobileNavItem
                     title="Library"
@@ -58,10 +56,11 @@ export const MobileNav : React.FC<MobileNavProps> = ({handleProfile}) => {
                     to="/shop"
                     value="shop"
                 />
-                <BottomNavigationAction
-                    label="Profile"
+                <MobileNavItem
+                    title="Profile"
                     icon={<ProfileIcon/>}
-                    onClick={handleProfile}
+                    to="/profile"
+                    value="profile"
                 />
                 <BottomNavigationAction
                     label="Logout" icon={<LogoutIcon/>}

--- a/src/features/Navigation/components/NavItem.tsx
+++ b/src/features/Navigation/components/NavItem.tsx
@@ -1,4 +1,4 @@
-import { ListItemButton } from "@mui/material";
+import { ListItemButton, } from "@mui/material";
 import {
     NavLink,
     NavLinkProps
@@ -16,10 +16,6 @@ export const NavItem: React.FC<NavItemProps> = (props) => {
     const { icon, title } = props;
     return (<ListItemButton
         component={NavLink}
-        activeStyle={{
-            fontWeight: "bold",
-            color: "black"
-        }}
         {...props}
     >
         <ListItemIcon>

--- a/src/features/Navigation/components/NavPlanItem.tsx
+++ b/src/features/Navigation/components/NavPlanItem.tsx
@@ -1,10 +1,14 @@
-import { TripOrigin as PlanIcon } from "@mui/icons-material";
+import {
+    RadioButtonChecked as ActivePlanIcon,
+    RadioButtonUnchecked as PlanIcon,
+} from "@mui/icons-material";
 import * as React from "react";
 import {
     ListItemButton,
     ListItemIcon,
     Typography
 } from "@mui/material";
+import useActivePlanner from "../../../data/useActivePlanner";
 
 type NavPlanItemProps = {
     id: string | number,
@@ -15,9 +19,13 @@ type NavPlanItemProps = {
 }
 
 export const NavPlanItem: React.FC<NavPlanItemProps> = ({onSelect, expanded, name, color, id}) => {
+    const active = useActivePlanner().data?.id === id;
+    const Icon = active
+        ? ActivePlanIcon
+        : PlanIcon;
     return (<ListItemButton onClick={() => onSelect(id)} key={id}>
         <ListItemIcon>
-            <PlanIcon sx={{color: color}}/>
+            <Icon sx={{ color: color }} />
         </ListItemIcon>
         <Typography noWrap>
             {expanded ? name : null}


### PR DESCRIPTION
Four changes in nav-refactor for beta:
1. put the "there's a new version" banner inside the nav pane so it doesn't flow under the sidebar
2. add `key` to the plan items in the sidebar to avoid react bitching
3. drive nav selection off the route, rather than internal state, so that mobile will match the URL on load, rather than always having library "selected", and share the logic between desktop/mobile
4. "check" the radio button of the active plan in the sidebar.