### PR TITLE
more nav twiddlage

### DIFF
--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,28 +1,33 @@
 import {
     blue,
     blueGrey,
-    green,
     indigo,
     lightGreen,
     lime,
-    pink,
     purple,
     red,
     teal
 } from "@mui/material/colors";
 
 export const planColors = [
+    // ¡¡ Make sure this always has a size equal to a power of 2 !!
     red[500],
-    pink[100],
     purple[400],
     indigo[900],
     blue[300],
     teal[300],
-    green[400],
     lightGreen[900],
     lime[500],
     blueGrey[500]
 ];
+
+if (process.env.NODE_ENV === "development") {
+    if (planColors.length !== Math.pow(2, Math.floor(Math.log2(planColors.length)))) {
+        // eslint-disable-next-line no-console
+        console.error("PlanColors has %s entries, which isn't a power of two!!",
+            planColors.length);
+    }
+}
 
 const ensureInt = (id: number | string) => {
     if (typeof id == "number") {
@@ -31,4 +36,15 @@ const ensureInt = (id: number | string) => {
     return parseInt(id, 10);
 };
 
-export const colorHash = (id: number | string) => planColors[ensureInt(id) % planColors.length];
+export const colorHash = (id: number | string) => {
+    const l = planColors.length;
+    let n = ensureInt(id);
+    let h = 0;
+    // This XORs all the bits of the number, instead of just the last few, which
+    // depends on the modulus being a power of two for a fair distribution.
+    while (n > 0) {
+        h ^= n % l;
+        n = Math.floor(n / l);
+    }
+    return planColors[h];
+};

--- a/src/features/Navigation/components/DesktopNav.tsx
+++ b/src/features/Navigation/components/DesktopNav.tsx
@@ -110,13 +110,15 @@ export const DesktopNav: React.FC<DesktopNavProps> = ({
             <Box sx={{alignItem: "bottom"}}>
                 <List>
                     <ListItemButton onClick={handleProfile}
+                                    title={"My Account"}
                                     selected={selected === "profile"}>
                         <ListItemIcon>
                             <ProfileIcon/>
                         </ListItemIcon>
                         <ListItemText id="profile" primary="My Account" sx={{whiteSpace: "nowrap"}}/>
                     </ListItemButton>
-                    <ListItemButton onClick={handleLogout}>
+                    <ListItemButton onClick={handleLogout}
+                                    title={"Logout"}>
                         <ListItemIcon>
                             <LogoutIcon/>
                         </ListItemIcon>

--- a/src/features/Navigation/components/NavPlanItem.tsx
+++ b/src/features/Navigation/components/NavPlanItem.tsx
@@ -23,7 +23,7 @@ export const NavPlanItem: React.FC<NavPlanItemProps> = ({onSelect, expanded, nam
     const Icon = active
         ? ActivePlanIcon
         : PlanIcon;
-    return (<ListItemButton onClick={() => onSelect(id)} key={id}>
+    return (<ListItemButton onClick={() => onSelect(id)} title={name}>
         <ListItemIcon>
             <Icon sx={{ color: color }} />
         </ListItemIcon>

--- a/src/views/common/FoodingerFab.tsx
+++ b/src/views/common/FoodingerFab.tsx
@@ -9,7 +9,9 @@ type AddFabProps = {
     isMobile?: boolean
 }
 
-const AddFab = styled(Fab)<AddFabProps>(({theme, isMobile}) => ({
+const AddFab = styled(Fab, {
+    shouldForwardProp: (prop) => prop !== "isMobile",
+})<AddFabProps>(({ theme, isMobile }) => ({
     position: "fixed",
     bottom: isMobile ? theme.spacing(8) : theme.spacing(3),
     right: theme.spacing(4),

--- a/src/views/user/Profile.tsx
+++ b/src/views/user/Profile.tsx
@@ -22,7 +22,7 @@ const Pic = styled(Box)(({theme}) => ({
 
 const Info = styled(Box)({
     flex: 1
-})
+});
 
 const ProfileDisplay = styled(Paper)(({theme}) => ({
     display: "flex",


### PR DESCRIPTION
1. show titles for plans and the account nav items
2. hash IDs for plan colors with all the available bits, hopefully for more uniform distribution across the colors
3. don't forward `isMobile` to the FAB after using it for styling
4. add missing semicolon for the linter