### PR TITLE
Drop shop items

### DIFF
--- a/src/containers/Shop.tsx
+++ b/src/containers/Shop.tsx
@@ -163,6 +163,7 @@ function groupItems(plans: PlanItem[],
                 blockId: ingId,
                 ingredient,
                 ...it,
+                acquiring: isAcquiring(it),
             })));
         }
     }

--- a/src/features/RecipeLibrary/data/LibraryStore.js
+++ b/src/features/RecipeLibrary/data/LibraryStore.js
@@ -3,15 +3,15 @@ import PantryItemActions from "data/PantryItemActions";
 import RecipeActions from "data/RecipeActions";
 import RecipeApi from "data/RecipeApi";
 import LibraryApi from "features/RecipeLibrary/data/LibraryApi";
-import { ReduceStore } from "flux/utils";
+import {ReduceStore} from "flux/utils";
 import invariant from "invariant";
 import PropTypes from "prop-types";
-import { clientOrDatabaseIdType } from "util/ClientId";
+import {clientOrDatabaseIdType} from "util/ClientId";
 import history from "util/history";
 import LoadObject from "util/LoadObject";
 import LoadObjectMap from "util/LoadObjectMap";
-import { loadObjectMapOf } from "util/loadObjectTypes";
-import { fromMilliseconds } from "util/time";
+import {loadObjectMapOf} from "util/loadObjectTypes";
+import {fromMilliseconds} from "util/time";
 import typedStore from "util/typedStore";
 import LibraryActions from "./LibraryActions";
 
@@ -81,6 +81,9 @@ class LibraryStore extends ReduceStore {
             }
 
             case LibraryActions.LOAD_INGREDIENTS: {
+                if (action.ids.length === 0) {
+                    return state;
+                }
                 LibraryApi.getIngredientInBulk(action.ids);
                 return {
                     ...state,
@@ -103,6 +106,9 @@ class LibraryStore extends ReduceStore {
             }
 
             case LibraryActions.INGREDIENTS_LOADED: {
+                if (action.data.length === 0) {
+                    return state;
+                }
                 return {
                     ...state,
                     byId: action.data.reduce((byId, it) =>

--- a/src/util/partition.ts
+++ b/src/util/partition.ts
@@ -1,0 +1,18 @@
+import groupBy from "./groupBy";
+
+/**
+ * I partition the passed items into two arrays, one with items that passed the
+ * test and one with items that didn't. This is a specialized {@link groupBy}.
+ *
+ * @param items The items to group by their test result
+ * @param test Predicate for testing the items.
+ */
+function partition<T>(items: T[], test: (t: T) => boolean | undefined): [ T[], T[] ] {
+    const map = groupBy(items, test);
+    return [
+        map.get(true) || [],
+        map.get(false) || [],
+    ];
+}
+
+export default partition;

--- a/src/views/shop/ShopList.tsx
+++ b/src/views/shop/ShopList.tsx
@@ -7,7 +7,7 @@ import ShoppingActions from "data/ShoppingActions";
 import FoodingerFab from "views/common/FoodingerFab";
 import LoadingIndicator from "views/common/LoadingIndicator";
 import PageBody from "views/common/PageBody";
-import Ingredient from "views/shop/IngredientItem";
+import IngredientItem from "views/shop/IngredientItem";
 import PlanItem from "views/shop/PlanItem";
 import {
     BaseItemProp,
@@ -22,7 +22,7 @@ export enum ShopItemType {
 }
 
 export interface ShopItemTuple extends ItemProps {
-    id: string | number
+    blockId?: string | number
     _type: ShopItemType
     active?: boolean
     depth: number
@@ -67,7 +67,7 @@ class ShopList extends React.PureComponent<ShopListProps> {
             <List>
                 {itemTuples.map(it => {
                     if (it._type === ShopItemType.INGREDIENT) {
-                        return <Ingredient
+                        return <IngredientItem
                             key={it.id + "-ing-item"}
                             item={it}
                             active={it.expanded}

--- a/src/views/shop/types.ts
+++ b/src/views/shop/types.ts
@@ -6,10 +6,12 @@ export type TupleProps = {
 export type BaseItemProp = {
     id: string | number
     name: string,
+    status?: string
 };
 
 export type ItemProps = BaseItemProp & {
     loading: boolean,
     deleting: boolean,
     acquiring: boolean,
+    needing?: boolean,
 };


### PR DESCRIPTION
When shopping items are marked as acquired, leave them in-place, but upon next window blur shift them to the bottom. Same thing in reverse: if an acquired items is unmarked (still needed), shift it back to the top upon next blur.

The idea is never to shift items around while they're in view, but every time you look back to the list it'll be properly partitioned.