### PR TITLE
Shop misaggregation

### DIFF
--- a/src/containers/Shop.tsx
+++ b/src/containers/Shop.tsx
@@ -237,11 +237,15 @@ const Shop = () => {
         handleRepartition();
     }, [ handleRepartition, plan?.id ]);
     const [ acquiredIds, setAcquiredIds ] = useState<Set<BfsId>>(new Set());
-    useEffect(() => {
-        setAcquiredIds(new Set(itemTuples
-            .filter(it => it.acquiring)
-            .map(it => it.id)));
-    }, [ partitionReqCount ]); // eslint-disable-line react-hooks/exhaustive-deps
+    useEffect(
+      () => {
+        setAcquiredIds(
+          new Set(itemTuples.filter((it) => it.acquiring).map((it) => it.id)),
+        );
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [partitionReqCount],
+    );
     const [ partitionedTuples, setPartitionedTuples ] = useState<ShopItemTuple[][]>([ [], [] ]);
     useEffect(() => {
         setPartitionedTuples(partition(

--- a/src/containers/Shop.tsx
+++ b/src/containers/Shop.tsx
@@ -129,8 +129,13 @@ function groupItems(plans: PlanItem[],
     const theTree: ShopItemTuple[] = [];
     for (const { id: ingId, items, data: ingredient, loading } of orderedIngredients) {
         if (items.length === 0) continue;
+        const allAcquiring = items.every(isAcquiring);
+        const someAcquiring = items.some(isAcquiring);
+        const toAgg = someAcquiring && !allAcquiring
+            ? items.filter(it => !isAcquiring(it))
+            : items;
         const unitLookup = new Map();
-        const byUnit = groupBy(items, it => {
+        const byUnit = groupBy(toAgg, it => {
             if (it.uomId) {
                 unitLookup.set(it.uomId, it.units);
             }
@@ -155,7 +160,7 @@ function groupItems(plans: PlanItem[],
             quantities,
             expanded,
             loading: loading || items.some(it => it.loading),
-            acquiring: items.every(isAcquiring),
+            acquiring: allAcquiring,
             deleting: items.every(it => it.deleting || it.status === PlanItemStatus.DELETED),
             depth: 0,
             path: [],

--- a/src/data/useFluxStore.ts
+++ b/src/data/useFluxStore.ts
@@ -44,7 +44,8 @@ function useFluxStore<S>(calculateState: () => S,
             setState(calculateState);
             return () => subs.reset();
         },
-        stores.concat(deps), // eslint-disable-line react-hooks/exhaustive-deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        stores.concat(deps),
     );
     return state;
 }

--- a/src/features/Planner/components/StatusIconButton.tsx
+++ b/src/features/Planner/components/StatusIconButton.tsx
@@ -34,6 +34,8 @@ const StatusIconButton: React.FC<Props> = props => {
     const Icn = getIconForStatus(props.next);
     return <Tooltip
         title={`Mark ${props.next.substring(0, 1)}${props.next.substring(1).toLowerCase()}`}
+        disableInteractive
+        enterDelay={750}
     >
         <Btn
             aria-label={props.next.toLowerCase()}


### PR DESCRIPTION
Partially acquired ingredients should only show what remains to be acquired, rather than everything. E.g., if I already acquired "1 c flour", and I need "2 Tbsp flour", the shopping list should show "flour (2 Tbsp)", not "flour (1 c and 2 Tbsp)". If you want to see the breakdown between acquired and not-acquired, expand the ingredient.