### PR TITLE
Fix flash of 404

### DIFF
--- a/src/features/RecipeDisplay/RecipeController.tsx
+++ b/src/features/RecipeDisplay/RecipeController.tsx
@@ -28,11 +28,12 @@ const RecipeController: React.FC<Props> = ({ match }) => {
         return <LoadingIndicator />;
     }
 
-    if (error || !fullRecipe) {
+    if (error) {
         return <NotFound />;
     }
 
     return (
+        fullRecipe &&
         fullRecipe.recipe && (
             <ScalingProvider>
                 <RecipeDetail

--- a/src/features/RecipeDisplay/hooks/useGetFullRecipe.ts
+++ b/src/features/RecipeDisplay/hooks/useGetFullRecipe.ts
@@ -49,38 +49,38 @@ export const useGetFullRecipe = (id: string): UseQueryResult<FullRecipe> => {
         }));
     }, [result]);
 
-    if (!result) {
+    if (result && !loading) {
+        const recipe: Recipe = {
+            calories: result.calories,
+            directions: result.directions || "",
+            externalUrl: result.externalUrl,
+            id: parseInt(result.id, 10),
+            ingredients,
+            labels: [],
+            name: result.name || "",
+            photo: result.photo?.url || null,
+            photoFocus: result.photo?.focus || [],
+            totalTime: result.totalTime,
+            yield: result.yield,
+        };
+
+        const fullRecipe: FullRecipe = {
+            mine: result.owner.id === myId.toString(),
+            owner: result.owner,
+            recipe,
+            subrecipes,
+        };
+
         return {
-            loading: false,
-            error: true,
-            data: null,
+            loading,
+            error,
+            data: fullRecipe,
         };
     }
-
-    const recipe: Recipe = {
-        calories: result.calories,
-        directions: result.directions || "",
-        externalUrl: result.externalUrl,
-        id: parseInt(result.id, 10),
-        ingredients,
-        labels: [],
-        name: result.name || "",
-        photo: result.photo?.url || null,
-        photoFocus: result.photo?.focus || [],
-        totalTime: result.totalTime,
-        yield: result.yield,
-    };
-
-    const fullRecipe: FullRecipe = {
-        mine: result.owner.id === myId.toString(),
-        owner: result.owner,
-        recipe,
-        subrecipes,
-    };
 
     return {
         loading,
         error,
-        data: fullRecipe,
+        data: null,
     };
 };


### PR DESCRIPTION
This PR adds a fix for the flash of 404 when a recipe is loading Issue #71 . The issue is that both a recipe that has been deleted and a recipe that is awaiting a response from the server are both null. This fix uses the loading state to distinguish what the correct UI should be.

I am also opening an additional ticket to investigate error handling from the API in the client, as I think a more permanent solution would be to throw an error when asking for a recipe that does not exist. At the very least, it would allow for more verbose messaging for users when they stumble upon a recipe that has been deleted.