### PR TITLE
Refactors library search query into a hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "build": "react-scripts build",
     "compile": "graphql-codegen",
     "test": "react-scripts test",
+    "pretest": "npm run compile",
     "posttest": "eslint --max-warnings 0 ./src",
     "eject": "react-scripts eject",
     "lint": "eslint ./src",

--- a/src/features/RecipeLibrary/LibraryController.tsx
+++ b/src/features/RecipeLibrary/LibraryController.tsx
@@ -1,11 +1,10 @@
-import { useQuery } from "@apollo/client";
 import { RecipesList } from "features/RecipeLibrary/components/RecipesList";
 import { useProfile } from "providers/Profile";
 import qs from "qs";
 import React, { useState } from "react";
 import { useHistory } from "react-router-dom";
 import { LibrarySearchScope } from "__generated__/graphql";
-import { SEARCH_RECIPES } from "features/RecipeLibrary/data/queries";
+import { useSearchLibrary } from "features/RecipeLibrary/hooks/useSearchLibrary";
 
 export const LibraryController = () => {
     const me = useProfile();
@@ -19,11 +18,16 @@ export const LibraryController = () => {
             ? LibrarySearchScope.Everyone
             : LibrarySearchScope.Mine,
     );
-    const { data, loading, refetch, fetchMore } = useQuery(SEARCH_RECIPES, {
-        variables: {
-            query,
-            scope,
-        },
+    const {
+        data: recipes,
+        loading,
+        refetch,
+        fetchMore,
+        isComplete,
+        endCursor,
+    } = useSearchLibrary({
+        scope,
+        query,
     });
 
     function handleSearch(newQuery, newScope) {
@@ -43,7 +47,7 @@ export const LibraryController = () => {
     function handleNeedMore() {
         return fetchMore({
             variables: {
-                after: data?.library?.recipes.pageInfo.endCursor,
+                after: endCursor,
             },
         });
     }
@@ -54,9 +58,9 @@ export const LibraryController = () => {
             onSearch={handleSearch}
             scope={scope}
             filter={query}
-            recipes={data?.library?.recipes.edges.map((e) => e.node)}
+            recipes={recipes}
             isLoading={loading}
-            isComplete={!data?.library?.recipes.pageInfo.hasNextPage}
+            isComplete={isComplete}
             onNeedMore={handleNeedMore}
         />
     );

--- a/src/features/RecipeLibrary/__tests__/RecipeLibrary.test.js
+++ b/src/features/RecipeLibrary/__tests__/RecipeLibrary.test.js
@@ -1,0 +1,41 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { MockedProvider } from "@apollo/client/testing";
+import { LibraryController } from "../LibraryController";
+
+const mocks = []; // We'll fill this in next
+
+jest.mock("providers/Profile", () => {
+    return {
+        useProfile: () => ({
+            id: 373,
+            name: "Brenna Switzer",
+            email: "brenna.switzer@gmail.com",
+            imageUrl:
+                "https://lh3.googleusercontent.com/a/ACg8ocLE73pCfyshoFIZPWqVVwYRZo8YG_Uk7sADqvfj7qInKSw=s96-c",
+            provider: "google",
+            roles: ["USER", "DEVELOPER"],
+        }),
+    };
+});
+
+jest.mock("react-router-dom", () => ({
+    useHistory: () => ({
+        location: {
+            search: "?q=creamy&s=MINE",
+        },
+    }),
+}));
+
+describe("Recipe Library", () => {
+    it("renders without error", async () => {
+        render(
+            <MockedProvider mocks={mocks} addTypename={false}>
+                <LibraryController />
+            </MockedProvider>,
+        );
+        expect(
+            await screen.findByText("Zero recipes matched your filter. 🙁"),
+        ).toBeInTheDocument();
+    });
+});

--- a/src/features/RecipeLibrary/data/queries.ts
+++ b/src/features/RecipeLibrary/data/queries.ts
@@ -1,7 +1,7 @@
 import { gql } from "__generated__";
 
 export const SEARCH_RECIPES = gql(`
-    query lib(
+    query getSearchLibrary(
         $query: String! = ""
         $scope: LibrarySearchScope! = MINE
         $first: NonNegativeInt! = 9
@@ -17,6 +17,8 @@ export const SEARCH_RECIPES = gql(`
                             id
                             imageUrl
                             name
+                            email
+                            provider
                         }
                         photo {
                             url

--- a/src/features/RecipeLibrary/data/queries.ts
+++ b/src/features/RecipeLibrary/data/queries.ts
@@ -17,8 +17,6 @@ export const SEARCH_RECIPES = gql(`
                             id
                             imageUrl
                             name
-                            email
-                            provider
                         }
                         photo {
                             url

--- a/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
+++ b/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
@@ -29,8 +29,6 @@ export const useSearchLibrary = ({
         },
     });
 
-    const isComplete = !data?.library?.recipes.pageInfo.hasNextPage;
-
     // e.node
     const recipes: RecipeCard[] =
         data?.library?.recipes.edges.map((it) => ({
@@ -51,7 +49,7 @@ export const useSearchLibrary = ({
         error,
         refetch,
         fetchMore,
-        isComplete,
+        isComplete: !data?.library?.recipes.pageInfo.hasNextPage,
         endCursor: data?.library?.recipes.pageInfo.endCursor,
         data: recipes,
     };

--- a/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
+++ b/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
@@ -1,0 +1,58 @@
+import { SEARCH_RECIPES } from "features/RecipeLibrary/data/queries";
+import { QueryResult, useQuery } from "@apollo/client";
+import type { RecipeCard } from "features/RecipeLibrary/types";
+import {
+    GetSearchLibraryQuery,
+    GetSearchLibraryQueryVariables,
+} from "__generated__/graphql";
+
+interface UseSearchLibraryQueryResult
+    extends Pick<
+        QueryResult,
+        "loading" | "error" | "refetch" | "fetchMore" | "data"
+    > {
+    isComplete: boolean;
+    endCursor: string;
+}
+
+export const useSearchLibrary = ({
+    scope,
+    query,
+}): UseSearchLibraryQueryResult => {
+    const { data, error, loading, refetch, fetchMore } = useQuery<
+        GetSearchLibraryQuery,
+        GetSearchLibraryQueryVariables
+    >(SEARCH_RECIPES, {
+        variables: {
+            query,
+            scope,
+        },
+    });
+
+    const isComplete = !data?.library?.recipes.pageInfo.hasNextPage;
+
+    // e.node
+    const recipes: RecipeCard[] =
+        data?.library?.recipes.edges.map((it) => ({
+            id: it.node.id,
+            name: it.node.name,
+            owner: it.node.owner,
+            calories: it.node.calories || null,
+            externalUrl: it.node.externalUrl || null,
+            favorite: it.node.favorite,
+            labels: it.node.labels || [],
+            photo: it.node.photo || null,
+            totalTime: it.node.totalTime || null,
+            yield: it.node.yield || null,
+        })) || [];
+
+    return {
+        loading,
+        error,
+        refetch,
+        fetchMore,
+        isComplete,
+        endCursor: data?.library?.recipes.pageInfo.endCursor,
+        data: recipes,
+    };
+};

--- a/src/features/RecipeLibrary/types.ts
+++ b/src/features/RecipeLibrary/types.ts
@@ -1,0 +1,14 @@
+import { Photo, User as UserType } from "__generated__/graphql";
+
+export interface RecipeCard {
+    id: string;
+    name: string;
+    owner: UserType;
+    calories?: number | null;
+    externalUrl?: string | null;
+    favorite: boolean;
+    labels?: string[] | null;
+    photo?: Photo | null;
+    totalTime?: number | null;
+    yield?: number | null;
+}

--- a/src/features/RecipeLibrary/types.ts
+++ b/src/features/RecipeLibrary/types.ts
@@ -1,7 +1,8 @@
 import { Photo, User as UserType } from "__generated__/graphql";
+import { BfsId } from "global/types/types";
 
 export interface RecipeCard {
-    id: string;
+    id: BfsId;
     name: string;
     owner: UserType;
     calories?: number | null;

--- a/src/features/RecipeLibrary/types.ts
+++ b/src/features/RecipeLibrary/types.ts
@@ -4,7 +4,7 @@ import { BfsId } from "global/types/types";
 export interface RecipeCard {
     id: BfsId;
     name: string;
-    owner: UserType;
+    owner: Partial<UserType>;
     calories?: number | null;
     externalUrl?: string | null;
     favorite: boolean;


### PR DESCRIPTION
This PR refactors the useQuery call in the LibraryController into it's own useSearchLibrary hook as prep for moving the library search into multiple UI experiences in GoBrennas. The idea is to create some more consistency in the code base and to start adding in tests so that we can encapsulate and refactor more easily in the future.

This PR should have no effect at all on the functionality of the library search.