### PR TITLE
GraphQL support for item recognition

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -108,7 +108,7 @@ type LibraryQuery {
     Please ignore; I exist because GraphQL defines the available types as
     those reachable from fields. Since PantryItem is currently only used
     polymorphically (e.g., by `Query`'s `node` field), it will not be included
-    in the available types.
+    in the available types without this dummy field.
     """
     pantryItem: PantryItem
     "Search the recipe library."
@@ -134,6 +134,22 @@ type LibraryQuery {
         "The scope to search for recipes within."
         scope: LibrarySearchScope! = MINE
     ): RecipeConnection!
+    """
+
+    Recognize quantity, unit, and/or ingredient in a raw ingredient ref (aka
+    item) string, and describe that structure. By default, also provide
+    suggestions based on partial matches.
+    """
+    recognizeItem(
+        """
+
+        The position of the cursor in the raw string, used to make contextual
+        suggestions. If not specified, the end of the raw string is assumed.
+        """
+        cursor: NonNegativeInt,
+        "The raw string to recognize."
+        raw: String!
+    ): RecognizedItem
 }
 
 type Mutation {
@@ -331,6 +347,46 @@ type RecipeConnectionEdge {
     node: Recipe!
 }
 
+"""
+
+A suggestion for what might come next at the cursor position, along with the
+target range of the raw string it would replace.
+"""
+type RecognitionSuggestion {
+    name: String!
+    target: RecognizedRange!
+}
+
+"The result of recognizing a raw ingredient ref item."
+type RecognizedItem {
+    "The position of the cursor in the raw string."
+    cursor: NonNegativeInt!
+    "Recognized ranges within the raw string."
+    ranges: [RecognizedRange!]!
+    "The raw string which was recognized."
+    raw: String!
+    """
+
+    Suggestions of what the user might wish to insert at the current cursor
+    position. If more than 'count' suggestions are available, the returned
+    subset is unspecified, other than pantry items are preferred to recipes.
+    """
+    suggestions(count: PositiveInt! = 10): [RecognitionSuggestion!]!
+}
+
+"""
+
+A recognized quantity in the raw string. The type indicates which of the id
+or quantity fields will be non-null, if either.
+"""
+type RecognizedRange {
+    end: NonNegativeInt!
+    id: ID
+    quantity: NonNegativeFloat
+    start: NonNegativeInt!
+    type: RecognizedRangeType!
+}
+
 type ShareInfo {
     id: ID!
     secret: String!
@@ -422,6 +478,15 @@ enum PlanItemStatus {
     NEEDED
 }
 
+enum RecognizedRangeType {
+    ITEM
+    NEW_ITEM
+    NEW_UNIT
+    QUANTITY
+    UNIT
+    UNKNOWN
+}
+
 "The type of a cursor, an opaque string used for walking connections."
 scalar Cursor
 
@@ -433,6 +498,9 @@ scalar DateTime
 
 "A 64-bit signed integer"
 scalar Long
+
+"An Float scalar that must be greater than or equal to zero"
+scalar NonNegativeFloat
 
 "An Int scalar that must be greater than or equal to zero"
 scalar NonNegativeInt

--- a/src/data/ItemApi.ts
+++ b/src/data/ItemApi.ts
@@ -1,6 +1,7 @@
 import BaseAxios from "axios";
 import { API_BASE_URL } from "../constants";
 import serializeObjectOfPromiseFns from "../util/serializeObjectOfPromiseFns";
+import { BfsId } from "../global/types/types";
 
 const axios = BaseAxios.create({
     baseURL: `${API_BASE_URL}/api`,
@@ -9,6 +10,8 @@ const axios = BaseAxios.create({
 export enum RecognitionRangeType {
     // noinspection JSUnusedGlobalSymbols
     UNKNOWN = "UNKNOWN",
+    QUANTITY = "QUANTITY",
+    // @deprecated - prefer QUANTITY
     AMOUNT = "AMOUNT",
     UNIT = "UNIT",
     NEW_UNIT = "NEW_UNIT",
@@ -20,6 +23,11 @@ interface RecognitionRange {
     start: number;
     end: number;
     type: RecognitionRangeType;
+    // for QUANTITY ranges, the numeric quantity
+    quantity: number;
+    // for UNIT and ITEM ranges, the object's ID
+    id: BfsId;
+    // @deprecated - prefer quantity or id, based on type
     value: number;
 }
 

--- a/src/util/processRecognizedItem.ts
+++ b/src/util/processRecognizedItem.ts
@@ -2,7 +2,11 @@
 import { RecognitionRangeType, RecognitionResult } from "../data/ItemApi";
 
 function processRecognizedItem(recog: RecognitionResult) {
-    const qr = recog.ranges.find((r) => r.type === RecognitionRangeType.AMOUNT);
+    const qr = recog.ranges.find(
+        (r) =>
+            r.type === RecognitionRangeType.QUANTITY ||
+            r.type === RecognitionRangeType.AMOUNT, // AMOUNT is deprecated
+    );
     const ur = recog.ranges.find(
         (r) =>
             r.type === RecognitionRangeType.UNIT ||
@@ -24,11 +28,11 @@ function processRecognizedItem(recog: RecognitionResult) {
         return s.substring(1, s.length - 1);
     };
     const q = textFromRange(qr);
-    const qv = qr && qr.value;
+    const qv = qr && (qr.quantity || qr.value); // value is deprecated
     const u = textFromRange(ur);
-    const uv = ur && ur.value;
+    const uv = ur && (ur.id || ur.value); // value is deprecated
     const n = textFromRange(nr);
-    const nv = nr && nr.value;
+    const nv = nr && (nr.id || nr.value); // value is deprecated
     const p = [qr, ur, nr]
         .filter((it) => it != null)
         .sort(

--- a/src/views/ElEdit.tsx
+++ b/src/views/ElEdit.tsx
@@ -13,9 +13,9 @@ export interface Value {
     id?: BfsId;
     raw: string;
     quantity?: number;
-    uomId?: number;
+    uomId?: BfsId;
     units?: string;
-    ingredientId?: number;
+    ingredientId?: BfsId;
     ingredient?: Ingredient;
     preparation?: string;
 }
@@ -54,9 +54,9 @@ interface ElEditState {
     quantity?: number;
     quantityValue?: number;
     unit?: string;
-    unitValue?: number;
+    unitValue?: BfsId;
     ingredientName?: string;
-    nameValue?: number;
+    nameValue?: BfsId;
     preparation?: string;
 }
 


### PR DESCRIPTION
The client-side updates corresponding to the REST-related portion of the folded-ear/gobrennas-api#28 changes. Not actually _using_ the new GraphQL pieces, just have them in the schemagen now.