### PR TITLE
send-to-plan clipping

### DIFF
--- a/src/features/RecipeLibrary/components/RecipeCard.tsx
+++ b/src/features/RecipeLibrary/components/RecipeCard.tsx
@@ -1,7 +1,6 @@
 import { MenuBook } from "@mui/icons-material";
 import {
     Box,
-    Button,
     Card,
     CardActions,
     CardContent,
@@ -26,6 +25,7 @@ import Source from "views/common/Source";
 import User from "views/user/User";
 import FavoriteIndicator from "../../Favorites/components/Indicator";
 import { Photo, User as UserType } from "../../../__generated__/graphql";
+import TextButton from "../../../views/common/TextButton";
 
 const useStyles = makeStyles({
     photo: {
@@ -159,8 +159,8 @@ const RecipeCard: React.FC<Props> = ({ recipe, mine, indicateMine, me }) => {
                 </CardContent>
             </>
             <CardActions>
-                <Stack direction="row" spacing={2}>
-                    <Button
+                <Stack direction="row" spacing={2} sx={{ maxWidth: "100%" }}>
+                    <TextButton
                         variant="contained"
                         color="secondary"
                         disableElevation
@@ -169,7 +169,7 @@ const RecipeCard: React.FC<Props> = ({ recipe, mine, indicateMine, me }) => {
                         to={`/library/recipe/${recipe.id}`}
                     >
                         View
-                    </Button>
+                    </TextButton>
                     <SendToPlan
                         onClick={(planId) =>
                             Dispatcher.dispatch({

--- a/src/features/RecipeLibrary/components/SendToPlan.tsx
+++ b/src/features/RecipeLibrary/components/SendToPlan.tsx
@@ -1,16 +1,8 @@
-import { Button, IconButton } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
-import { AddShoppingCart, ExitToApp } from "@mui/icons-material";
+import { IconButton } from "@mui/material";
+import { AddShoppingCart, ExitToApp as SendIcon } from "@mui/icons-material";
 import React from "react";
 import useActivePlanner from "data/useActivePlanner";
-
-const useStyles = makeStyles({
-    button: {
-        whiteSpace: "nowrap",
-        overflow: "hidden",
-        textOverflow: "ellipsis",
-    },
-});
+import TextButton from "../../../views/common/TextButton";
 
 interface Props {
     onClick(planId: number): void;
@@ -18,7 +10,6 @@ interface Props {
 }
 
 const SendToPlan: React.FC<Props> = ({ onClick, iconOnly }) => {
-    const classes = useStyles();
     const list = useActivePlanner().data;
     if (!list) return null;
     const handleClick = () =>
@@ -37,17 +28,16 @@ const SendToPlan: React.FC<Props> = ({ onClick, iconOnly }) => {
         );
     } else {
         return (
-            <Button
+            <TextButton
                 disableElevation
                 variant="contained"
                 color="secondary"
                 onClick={handleClick}
-                startIcon={<ExitToApp />}
+                title={`Send to ${list.name}`}
+                startIcon={<SendIcon />}
             >
-                <span className={classes.button} title={`Send to ${list.name}`}>
-                    To {list.name}
-                </span>
-            </Button>
+                To {list.name}
+            </TextButton>
         );
     }
 };

--- a/src/views/common/TextButton.tsx
+++ b/src/views/common/TextButton.tsx
@@ -1,0 +1,22 @@
+import makeStyles from "@mui/styles/makeStyles";
+import { Button } from "@mui/material";
+import React from "react";
+
+const useStyles = makeStyles({
+    body: {
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+    },
+});
+
+const TextButton = (({ children, ...props }) => {
+    const classes = useStyles();
+    return (
+        <Button {...props}>
+            <span className={classes.body}>{children}</span>
+        </Button>
+    );
+}) as typeof Button;
+
+export default TextButton;


### PR DESCRIPTION
With a long active plan, the recipe cards clip the send-to-plan button. Don't do that.

<img width="332" alt="image" src="https://github.com/folded-ear/gobrennas-client/assets/82654/61f1d8d1-4c3e-4380-85d0-3cb3615e40a9">

<img width="448" alt="image" src="https://github.com/folded-ear/gobrennas-client/assets/82654/b1bd4be3-f6a7-4ff8-bcda-dc36a9deb779">
