### PR TITLE
track whether nav's collapsed as a preference

### DIFF
--- a/src/data/UserActions.js
+++ b/src/data/UserActions.js
@@ -7,6 +7,7 @@ const UserActions = {
         enabled: PropTypes.bool.isRequired,
     }),
     SET_LAYOUT: "user/set-layout",
+    SET_NAV_COLLAPSED: "user/set-nav-collapsed",
 };
 
 export default UserActions;

--- a/src/data/preferencesStore.ts
+++ b/src/data/preferencesStore.ts
@@ -17,6 +17,7 @@ const PrefNames = {
     ACTIVE_SHOPPING_PLANS: "activeShoppingPlans",
     DEV_MODE: "devMode",
     LAYOUT: "layout",
+    NAV_COLLAPSED: "navCollapsed",
 };
 
 type State = Map<string, any>;
@@ -93,11 +94,21 @@ class PreferencesStore extends ReduceStore<State, FluxAction> {
                 if (!action.enabled) {
                     state = clearPref(state, PrefNames.LAYOUT);
                 }
-                return setPref(state, PrefNames.DEV_MODE, action.enabled);
+                return setPref(state, PrefNames.DEV_MODE, !!action.enabled);
             }
+
             case UserActions.SET_LAYOUT: {
                 return setPref(state, PrefNames.LAYOUT, action.layout);
             }
+
+            case UserActions.SET_NAV_COLLAPSED: {
+                return setPref(
+                    state,
+                    PrefNames.NAV_COLLAPSED,
+                    !!action.collapsed,
+                );
+            }
+
             default:
                 return state;
         }
@@ -116,11 +127,15 @@ class PreferencesStore extends ReduceStore<State, FluxAction> {
     }
 
     isDevMode() {
-        return this.getState().get(PrefNames.DEV_MODE) || false;
+        return !!this.getState().get(PrefNames.DEV_MODE);
     }
 
     getLayout() {
         return this.getState().get(PrefNames.LAYOUT) || "auto";
+    }
+
+    isNavCollapsed() {
+        return !!this.getState().get(PrefNames.NAV_COLLAPSED);
     }
 }
 

--- a/src/data/useIsDevMode.ts
+++ b/src/data/useIsDevMode.ts
@@ -1,5 +1,14 @@
 import preferencesStore from "data/preferencesStore";
 import useFluxStore from "./useFluxStore";
+import Dispatcher from "./dispatcher";
+import UserActions from "./UserActions";
+
+export function setDevMode(enabled: boolean) {
+    Dispatcher.dispatch({
+        type: UserActions.SET_DEV_MODE,
+        enabled,
+    });
+}
 
 function useIsDevMode(): boolean {
     return useFluxStore(() => preferencesStore.isDevMode(), [preferencesStore]);

--- a/src/data/useIsNavCollapsed.ts
+++ b/src/data/useIsNavCollapsed.ts
@@ -1,0 +1,20 @@
+import preferencesStore from "data/preferencesStore";
+import useFluxStore from "./useFluxStore";
+import Dispatcher from "./dispatcher";
+import UserActions from "./UserActions";
+
+export function setNavCollapsed(collapsed: boolean) {
+    Dispatcher.dispatch({
+        type: UserActions.SET_NAV_COLLAPSED,
+        collapsed,
+    });
+}
+
+function useIsNavCollapsed(): boolean {
+    return useFluxStore(
+        () => preferencesStore.isNavCollapsed(),
+        [preferencesStore],
+    );
+}
+
+export default useIsNavCollapsed;

--- a/src/features/Navigation/NavigationController.tsx
+++ b/src/features/Navigation/NavigationController.tsx
@@ -21,6 +21,9 @@ import friendStore from "../../data/FriendStore";
 import { zippedComparator } from "../../util/comparators";
 import Dispatcher from "../../data/dispatcher";
 import ShoppingActions from "../../data/ShoppingActions";
+import useIsNavCollapsed, {
+    setNavCollapsed,
+} from "../../data/useIsNavCollapsed";
 
 type NavigationControllerProps = {
     authenticated: boolean;
@@ -31,7 +34,7 @@ export const NavigationController: React.FC<NavigationControllerProps> = ({
     authenticated,
     children,
 }) => {
-    const [expanded, setExpanded] = React.useState<boolean>(true);
+    const expanded = !useIsNavCollapsed();
     const isMobile = useIsMobile();
     const devMode = useIsDevMode();
     const profileRLO = ripLoadObject(useProfileLO());
@@ -51,7 +54,7 @@ export const NavigationController: React.FC<NavigationControllerProps> = ({
         history.push("/profile");
     };
 
-    const handleExpand = () => setExpanded(!expanded);
+    const handleExpand = () => setNavCollapsed(expanded);
 
     const doLogout = useLogoutHandler();
 

--- a/src/features/RecipeLibrary/components/MessagePaper.tsx
+++ b/src/features/RecipeLibrary/components/MessagePaper.tsx
@@ -1,15 +1,17 @@
 import React, { ReactNode } from "react";
 import { Box, Paper, Typography } from "@mui/material";
 
-interface MessagePaperProps {
+interface P {
     primary: string;
-    children?: ReactNode;
+    children?: never;
 }
+interface C {
+    primary?: never;
+    children: ReactNode;
+}
+type Props = P | C;
 
-export const MessagePaper: React.FC<MessagePaperProps> = ({
-    primary,
-    children,
-}) => {
+export const MessagePaper: React.FC<Props> = ({ primary, children }) => {
     return (
         <Paper
             style={{

--- a/src/features/UserProfile/components/Developer.tsx
+++ b/src/features/UserProfile/components/Developer.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import useIsDevMode from "data/useIsDevMode";
+import useIsDevMode, { setDevMode } from "data/useIsDevMode";
 import Dispatcher from "data/dispatcher";
 import UserActions from "data/UserActions";
 import Divider from "@mui/material/Divider";
@@ -61,12 +61,7 @@ const DevMode: React.FC = () => {
 export const Developer: React.FC = () => {
     const isDevMode = useIsDevMode();
 
-    const handleDevModeChange = (e) => {
-        Dispatcher.dispatch({
-            type: UserActions.SET_DEV_MODE,
-            enabled: e.target.checked,
-        });
-    };
+    const handleDevModeChange = (e) => setDevMode(e.target.checked);
 
     return (
         <>


### PR DESCRIPTION
Store whether the nav bar is collapsed as a client preference, rather than as component state, so it persists across refreshes, including reauth.

closes #83 