### PR TITLE
add light/dark colors for beta

### DIFF
--- a/icons.sh
+++ b/icons.sh
@@ -16,7 +16,7 @@ fi
 
 if [ "$1" = "--beta" ]; then
   echo "Using beta's icon color"
-  sed -e 's/#F57F17/#2962FF/' -i '.prod' $SRC/*.svg
+  sed -e 's/#F57F17/#1976d2/' -i '.prod' $SRC/*.svg
 fi
 
 function spit() {
@@ -64,7 +64,7 @@ spit 150 mstile-150x150.png $SRC/logo.svg
 
 spit 180 apple-touch-icon.png $SRC/logo.svg
 sed -e 's/fill="#F57F17"/fill="none"/' $SRC/logo.svg > $OUT/safari-pinned-tab.svg
-sed -e 's/fill="#2962FF"/fill="none"/' -i '' $OUT/safari-pinned-tab.svg
+sed -e 's/fill="#1976d2"/fill="none"/' -i '' $OUT/safari-pinned-tab.svg
 
 for x in 16 32 48; do
   spit $x favicon-${x}x$x.png $SRC/logo.svg

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,13 +1,12 @@
 import { createTheme, responsiveFontSizes, Theme } from "@mui/material/styles";
 import { IS_BETA } from "./constants";
-import { blue } from "@mui/material/colors";
 
 let theme: Theme = createTheme({
     palette: {
         primary: {
-            light: "#F99339",
-            main: IS_BETA ? blue["A700"] : "#F57F17",
-            dark: "#B85600",
+            light: IS_BETA ? "#90caf9" : "#F99339",
+            main: IS_BETA ? "#1976d2" : "#F57F17",
+            dark: IS_BETA ? "#0d47a1" : "#B85600",
             contrastText: "#FFFDE7",
         },
         secondary: {


### PR DESCRIPTION
To this point beta has only had a primary color override, so it's blue buttons hover to burnt orange. But no more! Also reduce the saturation a little, because _wow_.

closes #99 