### PR TITLE
Change close to goback

### DIFF
--- a/src/features/RecipeDisplay/RecipeController.tsx
+++ b/src/features/RecipeDisplay/RecipeController.tsx
@@ -75,9 +75,7 @@ const RecipeController: React.FC<Props> = ({ match }) => {
                                     }
                                 />
                             )}
-                            <CloseButton
-                                onClick={() => history.push("/library")}
-                            />
+                            <CloseButton onClick={() => history.goBack()} />
                         </>
                     }
                     canFavorite


### PR DESCRIPTION
Changing the routing back to the library to be a simple "back" button so that we can keep search results on closing a recipe.