### PR TITLE
Clear search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,8 +53,8 @@
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.0",
-        "@graphql-codegen/cli": "^5.0.2",
-        "@graphql-codegen/client-preset": "^4.2.4",
+        "@graphql-codegen/cli": "5.0.2",
+        "@graphql-codegen/client-preset": "4.2.4",
         "@testing-library/jest-dom": "^5.12.0",
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",

--- a/src/features/RecipeLibrary/components/RecipesList.tsx
+++ b/src/features/RecipeLibrary/components/RecipesList.tsx
@@ -49,7 +49,7 @@ export const RecipesList: React.FC<RecipesListProps> = ({
         e.preventDefault();
         e.stopPropagation();
         setUnsavedFilter("");
-        onSearch(unsavedFilter, scope);
+        onSearch("", scope);
     }
 
     function handleSearch(e) {


### PR DESCRIPTION
When clearing library search, update the results to "all", instead of leaving the prior result.