### PR TITLE
Adds a link to edit a recipe to the card buttons

### DIFF
--- a/src/features/RecipeLibrary/components/RecipeCard.tsx
+++ b/src/features/RecipeLibrary/components/RecipeCard.tsx
@@ -1,4 +1,4 @@
-import { MenuBook } from "@mui/icons-material";
+import { Edit as EditIcon, Visibility as ViewIcon } from "@mui/icons-material";
 import {
     Box,
     Card,
@@ -25,7 +25,7 @@ import Source from "views/common/Source";
 import User from "views/user/User";
 import FavoriteIndicator from "../../Favorites/components/Indicator";
 import { Photo, User as UserType } from "../../../__generated__/graphql";
-import TextButton from "../../../views/common/TextButton";
+import { TaskIcon } from "global/components/TaskIcon";
 
 const useStyles = makeStyles({
     photo: {
@@ -159,17 +159,15 @@ const RecipeCard: React.FC<Props> = ({ recipe, mine, indicateMine, me }) => {
                 </CardContent>
             </>
             <CardActions>
-                <Stack direction="row" spacing={2} sx={{ maxWidth: "100%" }}>
-                    <TextButton
-                        variant="contained"
-                        color="secondary"
-                        disableElevation
-                        startIcon={<MenuBook />}
-                        component={Link}
-                        to={`/library/recipe/${recipe.id}`}
-                    >
-                        View
-                    </TextButton>
+                <Stack direction="row" spacing={1} sx={{ maxWidth: "100%" }}>
+                    <TaskIcon
+                        icon={<ViewIcon />}
+                        url={`/library/recipe/${recipe.id}`}
+                    />
+                    <TaskIcon
+                        icon={<EditIcon />}
+                        url={`/library/recipe/${recipe.id}/edit`}
+                    />
                     <SendToPlan
                         onClick={(planId) =>
                             Dispatcher.dispatch({

--- a/src/global/components/TaskIcon.tsx
+++ b/src/global/components/TaskIcon.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { ReactNode } from "react";
+import { Button, IconButton } from "@mui/material";
+import { Link } from "react-router-dom";
+import { styled } from "@mui/material/styles";
+
+const ContainedIcon = styled(IconButton)(({ theme }) => ({
+    backgroundColor: theme.palette.neutral.main,
+    borderRadius: theme.shape.borderRadius,
+    color: theme.palette.neutral.contrastText,
+    "&:hover": {
+        backgroundColor: theme.palette.neutral.main,
+    },
+})) as typeof Button;
+
+type TaskIconProps = {
+    icon: ReactNode;
+    url: string;
+};
+
+export const TaskIcon: React.FC<TaskIconProps> = ({ icon, url }) => {
+    return (
+        <ContainedIcon size="small" color="secondary" component={Link} to={url}>
+            {icon}
+        </ContainedIcon>
+    );
+};

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,5 +1,16 @@
 import { createTheme, responsiveFontSizes, Theme } from "@mui/material/styles";
+import { grey } from "@mui/material/colors";
 import { IS_BETA } from "./constants";
+
+declare module "@mui/material/styles" {
+    interface Palette {
+        neutral: Palette["primary"];
+    }
+
+    interface PaletteOptions {
+        neutral?: PaletteOptions["primary"];
+    }
+}
 
 let theme: Theme = createTheme({
     palette: {
@@ -19,6 +30,12 @@ let theme: Theme = createTheme({
         // },
         background: {
             default: "#f7f7f7",
+        },
+        neutral: {
+            light: grey[100],
+            main: grey[200],
+            dark: grey[700],
+            contrastText: grey[900],
         },
     },
     typography: {


### PR DESCRIPTION
This PR edits the recipe card to show both a view and an edit link to the bottom button group, condensing the buttons to make them less obtrusive and more useful.