### PR TITLE
Make the delete button less ridiculous

### DIFF
--- a/src/features/Planner/components/PlanSidebar.tsx
+++ b/src/features/Planner/components/PlanSidebar.tsx
@@ -194,7 +194,7 @@ const PlanSidebar: React.FC<Props> = ({ plan }) => {
                     }}
                 >
                     <DeleteButton
-                        type="plan"
+                        forType="plan"
                         onConfirm={handleDelete}
                         label="Delete Plan"
                     />

--- a/src/features/RecipeDisplay/RecipeController.tsx
+++ b/src/features/RecipeDisplay/RecipeController.tsx
@@ -68,7 +68,7 @@ const RecipeController: React.FC<Props> = ({ match }) => {
                             )}
                             {fullRecipe.mine && (
                                 <DeleteButton
-                                    type="recipe"
+                                    forType="recipe"
                                     onConfirm={() =>
                                         RecipeApi.deleteRecipe(
                                             fullRecipe.recipe.id,

--- a/src/features/RecipeEdit/RecipeEditController.tsx
+++ b/src/features/RecipeEdit/RecipeEditController.tsx
@@ -83,7 +83,9 @@ const RecipeEditController: React.FC<Props> = ({ match }) => {
                 labelList={labelList}
                 extraButtons={
                     <DeleteButton
-                        type="recipe"
+                        variant="text"
+                        color="error"
+                        forType="recipe"
                         label="Delete Recipe"
                         onConfirm={() => handleDelete(recipe.id)}
                     />

--- a/src/features/RecipeEdit/components/TextractQueueBrowser.tsx
+++ b/src/features/RecipeEdit/components/TextractQueueBrowser.tsx
@@ -131,7 +131,7 @@ const Ui: React.FC<UiProps> = ({
                                     (j.state === "ready" ||
                                         j.state === "extracting") && (
                                         <DeleteButton
-                                            type="photo"
+                                            forType="photo"
                                             onConfirm={() => onDelete(j.id)}
                                             className={classes.deleteButton}
                                         />

--- a/src/views/common/DeleteButton.tsx
+++ b/src/views/common/DeleteButton.tsx
@@ -1,4 +1,4 @@
-import { Button, IconButton, Tooltip } from "@mui/material";
+import { Button, ButtonProps, IconButton, Tooltip } from "@mui/material";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogTitle from "@mui/material/DialogTitle";
@@ -19,16 +19,16 @@ const DeleteIconButton: React.FC<Props> = ({ onClick, ...props }) => (
 );
 
 type DeleteButtonProps = {
-    type: string;
+    forType: string;
     onConfirm(): void;
     label?: string;
     onClick?(): void;
     onCancel?(): void;
     className?: string;
-};
+} & ButtonProps;
 
 const DeleteButton: React.FC<DeleteButtonProps> = ({
-    type,
+    forType,
     onConfirm,
     label,
     onClick,
@@ -75,7 +75,7 @@ const DeleteButton: React.FC<DeleteButtonProps> = ({
                 aria-describedby="alert-dialog-description"
             >
                 <DialogTitle id="alert-dialog-title">
-                    Irrevocably delete this {type}?
+                    Irrevocably delete this {forType}?
                 </DialogTitle>
                 <DialogActions>
                     <Button onClick={handleCancel}>Cancel</Button>


### PR DESCRIPTION
This changes the style of the delete button from the recipe edit form to make it less confusing -- a stopgap until the edit form is reworked.