### PR TITLE
Cook planned stuff

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -32,5 +32,5 @@ body {
     }
 }
 .MuiDataGrid-row.duplicates-of {
-    background-color: #fffdd5;
+    background-color: #fff9c4; // `yellow[100]` from Material
 }

--- a/src/data/snackBarStore.js
+++ b/src/data/snackBarStore.js
@@ -1,6 +1,8 @@
 import { Button } from "@mui/material";
 import PlanActions from "features/Planner/data/PlanActions";
-import { willStatusDelete } from "features/Planner/data/PlanItemStatus";
+import PlanItemStatus, {
+    willStatusDelete,
+} from "features/Planner/data/PlanItemStatus";
 import planStore from "features/Planner/data/planStore";
 import LibraryStore from "features/RecipeLibrary/data/LibraryStore";
 import { ReduceStore } from "flux/utils";
@@ -50,7 +52,10 @@ const forPlanItemStatusChanges = (state, ids, status) => {
                         });
                     }}
                 >
-                    Delete {comps.length === 1 ? "It" : "Them"}
+                    {status === PlanItemStatus.COMPLETED
+                        ? "I Cooked"
+                        : "Delete"}{" "}
+                    {comps.length === 1 ? "It" : "Them"}
                 </Button>
             );
         },

--- a/src/features/Planner/components/CookedItButton.tsx
+++ b/src/features/Planner/components/CookedItButton.tsx
@@ -9,9 +9,10 @@ import history from "util/history";
 
 type Props = Omit<ButtonProps, "onClick"> & {
     recipe: FromPlanItem;
+    stayOnPage?: boolean;
 };
 
-const CookButton: React.FC<Props> = ({ recipe, ...props }) => {
+const CookButton: React.FC<Props> = ({ recipe, stayOnPage, ...props }) => {
     const pending = recipe.completing;
     const disabled =
         recipe.ancestorCompleting || recipe.deleting || recipe.ancestorDeleting;
@@ -25,9 +26,9 @@ const CookButton: React.FC<Props> = ({ recipe, ...props }) => {
                 id: recipe.id,
                 status: PlanItemStatus.COMPLETED,
             });
-            history.goBack();
+            if (!stayOnPage) history.goBack();
         },
-        [recipe.completing, recipe.id],
+        [recipe.completing, recipe.id, stayOnPage],
     );
 
     const text = pending ? "WAIT, NO!" : "I Cooked It!";

--- a/src/features/Planner/components/CookedItButton.tsx
+++ b/src/features/Planner/components/CookedItButton.tsx
@@ -1,0 +1,54 @@
+import { Button, ButtonProps, Tooltip } from "@mui/material";
+import { CookedItIcon } from "views/common/icons";
+import React, { useCallback } from "react";
+import { FromPlanItem } from "../../../global/types/types";
+import dispatcher from "../../../data/dispatcher";
+import PlanActions from "../data/PlanActions";
+import PlanItemStatus from "../data/PlanItemStatus";
+import history from "util/history";
+
+type Props = Omit<ButtonProps, "onClick"> & {
+    recipe: FromPlanItem;
+};
+
+const CookButton: React.FC<Props> = ({ recipe, ...props }) => {
+    const pending = recipe.completing;
+    const disabled =
+        recipe.ancestorCompleting || recipe.deleting || recipe.ancestorDeleting;
+    const handleClick = useCallback(
+        (e) => {
+            e.preventDefault();
+            dispatcher.dispatch({
+                type: recipe.completing
+                    ? PlanActions.UNDO_SET_STATUS
+                    : PlanActions.SET_STATUS,
+                id: recipe.id,
+                status: PlanItemStatus.COMPLETED,
+            });
+            history.goBack();
+        },
+        [recipe.completing, recipe.id],
+    );
+
+    const text = pending ? "WAIT, NO!" : "I Cooked It!";
+    const title = pending
+        ? text
+        : "Mark this cooked and remove it from the plan.";
+    return (
+        <Tooltip title={title} placement="bottom">
+            <Button
+                color={"success"}
+                startIcon={<CookedItIcon />}
+                disabled={disabled}
+                onClick={handleClick}
+                variant={pending ? "contained" : "outlined"}
+                size={"small"}
+                {...props}
+            >
+                {text}
+            </Button>
+        </Tooltip>
+    );
+};
+
+export default CookButton;

--- a/src/features/Planner/components/DontChangeStatusButton.tsx
+++ b/src/features/Planner/components/DontChangeStatusButton.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler } from "react";
+import React from "react";
 import Dispatcher from "data/dispatcher";
 import PlanActions from "features/Planner/data/PlanActions";
 import PlanItemStatus, {
@@ -6,6 +6,7 @@ import PlanItemStatus, {
 } from "features/Planner/data/PlanItemStatus";
 import { coloredButton } from "views/common/colors";
 import { BfsId } from "global/types/identity";
+import { ButtonProps } from "@mui/material";
 
 const buttonLookup = {}; // Map<next, Button>
 const findButton = (next) => {
@@ -15,14 +16,13 @@ const findButton = (next) => {
     return buttonLookup[next];
 };
 
-interface Props {
+interface Props extends Omit<ButtonProps, "id"> {
     next: PlanItemStatus;
     id?: BfsId;
-    onClick?: MouseEventHandler;
 }
 
-const DontChangeStatusButton: React.FC<Props> = (props) => {
-    const Btn = findButton(props.next);
+const DontChangeStatusButton: React.FC<Props> = ({ id, next, ...props }) => {
+    const Btn = findButton(next);
     return (
         <Btn
             variant="contained"
@@ -32,7 +32,7 @@ const DontChangeStatusButton: React.FC<Props> = (props) => {
                 e.stopPropagation();
                 Dispatcher.dispatch({
                     type: PlanActions.UNDO_SET_STATUS,
-                    id: props.id,
+                    id,
                 });
             }}
             {...props}

--- a/src/features/Planner/components/PlanItem.js
+++ b/src/features/Planner/components/PlanItem.js
@@ -209,6 +209,7 @@ class PlanItem extends React.PureComponent {
         const expanded = isExpanded(item);
         const recipeIsh = parent || item.fromRecipe;
         const question = isQuestionable(item);
+        const completing = item._next_status === PlanItemStatus.COMPLETED;
         const deleting = item._next_status === PlanItemStatus.DELETED;
         const acquiring = item._next_status === PlanItemStatus.ACQUIRED;
         const needing = item._next_status === PlanItemStatus.NEEDED;
@@ -228,7 +229,7 @@ class PlanItem extends React.PureComponent {
             );
         }
         const curr = item._next_status || item.status;
-        if (loading || deleting || ancestorDeleting) {
+        if (loading || completing || deleting || ancestorDeleting) {
             addonBefore.push(<LoadingIconButton key="acquire" />);
         } else if (section) {
             addonBefore.push(
@@ -249,7 +250,7 @@ class PlanItem extends React.PureComponent {
             );
         }
         const addonAfter = [
-            deleting && !ancestorDeleting ? (
+            (completing || deleting) && !ancestorDeleting ? (
                 <DontChangeStatusButton
                     key="delete"
                     id={item.id}
@@ -268,7 +269,7 @@ class PlanItem extends React.PureComponent {
                 />
             ),
         ];
-        if (recipeIsh) {
+        if (recipeIsh && !(completing || deleting)) {
             addonAfter.unshift(
                 <CookButton
                     key="cook"
@@ -278,7 +279,7 @@ class PlanItem extends React.PureComponent {
                 />,
             );
         }
-        if (buckets && buckets.length > 0) {
+        if (buckets && buckets.length > 0 && !(completing || deleting)) {
             addonAfter.unshift(
                 <PlanItemBucketChip
                     key="bucket"
@@ -301,6 +302,7 @@ class PlanItem extends React.PureComponent {
                     [classes.active]: active,
                     [classes.selected]: selected,
                     [classes.question]: question,
+                    [classes.completing]: completing,
                     [classes.deleting]: deleting,
                     [classes.acquiring]: acquiring,
                     [classes.needing]: needing,

--- a/src/features/Planner/data/planStore.js
+++ b/src/features/Planner/data/planStore.js
@@ -1359,7 +1359,9 @@ class PlanStore extends ReduceStore {
         const queue = t.componentIds.slice();
         const result = [];
         while (queue.length) {
-            const comp = taskForId(state, queue.shift());
+            const lo = loForId(state, queue.shift());
+            if (!lo.hasValue()) continue;
+            const comp = lo.getValueEnforcing();
             // walk upward and see if it's within the tree...
             let curr = comp;
             let descendant = false;

--- a/src/features/RecipeDisplay/PlannedBucketController.tsx
+++ b/src/features/RecipeDisplay/PlannedBucketController.tsx
@@ -9,6 +9,7 @@ import { useLoadedPlan } from "features/RecipeDisplay/hooks/useLoadedPlan";
 import { recipeLoByItemAndBucket } from "features/RecipeDisplay/utils/recipeLoByItemAndBucket";
 import CloseButton from "../../views/common/CloseButton";
 import history from "../../util/history";
+import CookedItButton from "features/Planner/components/CookedItButton";
 
 type Props = RouteComponentProps<{
     pid: string;
@@ -27,12 +28,17 @@ const PlannedBucketController: React.FC<Props> = ({ match }) => {
     useLoadedPlan(pid);
 
     if (lo.hasValue()) {
+        const recipe = lo.getValueEnforcing();
         return (
             <RecipeDetail
-                recipe={lo.getValueEnforcing()}
-                subrecipes={lo.getValueEnforcing().subrecipes}
+                recipe={recipe}
+                subrecipes={recipe.subrecipes}
                 nav={
                     <>
+                        {recipe.libraryRecipeId != null && (
+                            // only if the bucket is a single recipe
+                            <CookedItButton recipe={recipe} />
+                        )}
                         <CloseButton
                             onClick={() => history.push(`/plan/${pid}`)}
                         />

--- a/src/features/RecipeDisplay/PlannedRecipeController.tsx
+++ b/src/features/RecipeDisplay/PlannedRecipeController.tsx
@@ -11,6 +11,7 @@ import CloseButton from "../../views/common/CloseButton";
 import history from "../../util/history";
 import LoadObject from "util/LoadObject";
 import { RecipeFromPlanItem } from "global/types/types";
+import CookedItButton from "features/Planner/components/CookedItButton";
 
 type Props = RouteComponentProps<{
     pid: string;
@@ -28,12 +29,14 @@ const PlannedRecipeController: React.FC<Props> = ({ match }) => {
     useLoadedPlan(match.params.pid);
 
     if (lo.hasValue()) {
+        const recipe = lo.getValueEnforcing();
         return (
             <RecipeDetail
-                recipe={lo.getValueEnforcing()}
-                subrecipes={lo.getValueEnforcing().subrecipes}
+                recipe={recipe}
+                subrecipes={recipe.subrecipes}
                 nav={
                     <>
+                        <CookedItButton recipe={recipe} />
                         <CloseButton
                             onClick={() =>
                                 history.push(`/plan/${match.params.pid}`)

--- a/src/features/RecipeDisplay/components/SubrecipeItem.tsx
+++ b/src/features/RecipeDisplay/components/SubrecipeItem.tsx
@@ -48,7 +48,7 @@ const SubrecipeItem: React.FC<Props> = ({ recipe, loggedIn }) => {
                     </Stack>
                     {expanded && recipe.libraryRecipeId && (
                         <Stack direction={"row"} alignItems={"center"} gap={1}>
-                            <CookedItButton recipe={recipe} />
+                            <CookedItButton recipe={recipe} stayOnPage />
                             <BreadcrumbLink
                                 text="Open Library Recipe"
                                 url={`/library/recipe/${recipe.libraryRecipeId}`}

--- a/src/features/RecipeDisplay/components/SubrecipeItem.tsx
+++ b/src/features/RecipeDisplay/components/SubrecipeItem.tsx
@@ -1,5 +1,4 @@
-import { Divider, Grid, Stack, Typography } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { Box, Divider, Grid, Stack, Typography } from "@mui/material";
 import React from "react";
 import { formatDuration } from "util/time";
 import CollapseIconButton from "global/components/CollapseIconButton";
@@ -7,13 +6,7 @@ import IngredientDirectionsRow from "./IngredientDirectionsRow";
 import { ScalingProvider } from "util/ScalingContext";
 import type { Subrecipe } from "global/types/types";
 import { BreadcrumbLink } from "../../../global/components/BreadcrumbLink";
-
-const useStyles = makeStyles({
-    time: {
-        display: "inline-block",
-        fontSize: "80%",
-    },
-});
+import CookedItButton from "../../Planner/components/CookedItButton";
 
 interface Props {
     recipe: Subrecipe;
@@ -21,40 +14,46 @@ interface Props {
 }
 
 const SubrecipeItem: React.FC<Props> = ({ recipe, loggedIn }) => {
-    const classes = useStyles();
     const [expanded, setExpanded] = React.useState(false);
     return (
         <>
             <Grid item xs={12}>
-                <Stack direction={"row"} gap={1} alignItems={"center"}>
-                    <CollapseIconButton
-                        expanded={expanded}
-                        onClick={() => setExpanded((s) => !s)}
-                    />
-                    <Typography
-                        variant="h5"
-                        mb={0}
-                        onClick={() => setExpanded((s) => !s)}
-                        style={{
-                            cursor: "pointer",
-                        }}
-                    >
-                        {recipe.name}
-                    </Typography>
-                    {recipe.totalTime && (
-                        <Typography
-                            variant={"subtitle1"}
-                            component={"span"}
-                            className={classes.time}
-                        >
-                            ({formatDuration(recipe.totalTime)})
-                        </Typography>
-                    )}
-                    {expanded && recipe.libraryRecipeId && (
-                        <BreadcrumbLink
-                            text="Open Library Recipe"
-                            url={`/library/recipe/${recipe.libraryRecipeId}`}
+                <Stack direction={"row"} justifyContent={"space-between"}>
+                    <Stack direction={"row"} alignItems={"center"}>
+                        <CollapseIconButton
+                            expanded={expanded}
+                            onClick={() => setExpanded((s) => !s)}
                         />
+                        <Typography
+                            variant="h5"
+                            mb={0}
+                            onClick={() => setExpanded((s) => !s)}
+                            style={{
+                                cursor: "pointer",
+                            }}
+                        >
+                            {recipe.name}
+                        </Typography>
+                        {recipe.totalTime && (
+                            <Box ml={1}>
+                                <Typography
+                                    variant={"subtitle1"}
+                                    component={"span"}
+                                    fontSize={"80%"}
+                                >
+                                    ({formatDuration(recipe.totalTime)})
+                                </Typography>
+                            </Box>
+                        )}
+                    </Stack>
+                    {expanded && recipe.libraryRecipeId && (
+                        <Stack direction={"row"} alignItems={"center"} gap={1}>
+                            <CookedItButton recipe={recipe} />
+                            <BreadcrumbLink
+                                text="Open Library Recipe"
+                                url={`/library/recipe/${recipe.libraryRecipeId}`}
+                            />
+                        </Stack>
                     )}
                 </Stack>
             </Grid>

--- a/src/features/RecipeDisplay/components/SubrecipeItem.tsx
+++ b/src/features/RecipeDisplay/components/SubrecipeItem.tsx
@@ -1,5 +1,11 @@
-import { Box, Divider, Grid, Stack, Typography } from "@mui/material";
-import React from "react";
+import {
+    Divider,
+    Grid,
+    Stack,
+    Typography,
+    TypographyProps,
+} from "@mui/material";
+import React, { useCallback } from "react";
 import { formatDuration } from "util/time";
 import CollapseIconButton from "global/components/CollapseIconButton";
 import IngredientDirectionsRow from "./IngredientDirectionsRow";
@@ -7,6 +13,11 @@ import { ScalingProvider } from "util/ScalingContext";
 import type { Subrecipe } from "global/types/types";
 import { BreadcrumbLink } from "../../../global/components/BreadcrumbLink";
 import CookedItButton from "../../Planner/components/CookedItButton";
+import { styled } from "@mui/material/styles";
+
+const ActiveTypography = styled(Typography)<TypographyProps>({
+    cursor: "pointer",
+});
 
 interface Props {
     recipe: Subrecipe;
@@ -15,6 +26,7 @@ interface Props {
 
 const SubrecipeItem: React.FC<Props> = ({ recipe, loggedIn }) => {
     const [expanded, setExpanded] = React.useState(false);
+    const toggleExpanded = useCallback(() => setExpanded((s) => !s), []);
     return (
         <>
             <Grid item xs={12}>
@@ -22,28 +34,25 @@ const SubrecipeItem: React.FC<Props> = ({ recipe, loggedIn }) => {
                     <Stack direction={"row"} alignItems={"center"}>
                         <CollapseIconButton
                             expanded={expanded}
-                            onClick={() => setExpanded((s) => !s)}
+                            onClick={toggleExpanded}
                         />
-                        <Typography
+                        <ActiveTypography
                             variant="h5"
                             mb={0}
-                            onClick={() => setExpanded((s) => !s)}
-                            style={{
-                                cursor: "pointer",
-                            }}
+                            onClick={toggleExpanded}
                         >
                             {recipe.name}
-                        </Typography>
+                        </ActiveTypography>
                         {recipe.totalTime && (
-                            <Box ml={1}>
-                                <Typography
-                                    variant={"subtitle1"}
-                                    component={"span"}
-                                    fontSize={"80%"}
-                                >
-                                    ({formatDuration(recipe.totalTime)})
-                                </Typography>
-                            </Box>
+                            <ActiveTypography
+                                ml={1}
+                                variant={"subtitle1"}
+                                component={"span"}
+                                onClick={toggleExpanded}
+                                fontSize={"80%"}
+                            >
+                                ({formatDuration(recipe.totalTime)})
+                            </ActiveTypography>
                         )}
                     </Stack>
                     {expanded && recipe.libraryRecipeId && (

--- a/src/features/RecipeDisplay/utils/recipeLoByItemAndBucket.ts
+++ b/src/features/RecipeDisplay/utils/recipeLoByItemAndBucket.ts
@@ -30,16 +30,16 @@ export const recipeLoByItemAndBucket = (
     return buildSingleItemRecipeLO(
         LoadObject.withValue({
             name: getBucketLabel(bucket),
-            subtaskIds: items.map((it) => it.id),
+            componentIds: items.map((it) => it.id),
         }),
     ).map((r) => {
         const idToIdx = new Map();
-        r.subtaskIds.forEach((id, i) => idToIdx.set(id, i));
+        items.forEach((it, i) => idToIdx.set(it.id, i));
         const itToSubIdx = new Map();
         r.subrecipes.forEach((it) =>
             itToSubIdx.set(it, idToIdx.has(it.id) ? idToIdx.get(it.id) : -1),
         );
-        const withPhoto = r.subrecipes
+        const recipeWithPhoto = r.subrecipes
             .slice()
             .sort((a, b) => {
                 const ai = itToSubIdx.get(a);
@@ -49,11 +49,11 @@ export const recipeLoByItemAndBucket = (
                 return 0;
             })
             .find((it) => it.photo);
-        return withPhoto
+        return recipeWithPhoto
             ? {
                   ...r,
-                  photo: withPhoto.photo,
-                  photoFocus: withPhoto.photoFocus,
+                  photo: recipeWithPhoto.photo,
+                  photoFocus: recipeWithPhoto.photoFocus,
               }
             : r;
     });

--- a/src/features/RecipeDisplay/utils/recipeLoByItemLo.ts
+++ b/src/features/RecipeDisplay/utils/recipeLoByItemLo.ts
@@ -2,6 +2,7 @@ import LoadObject from "../../../util/LoadObject";
 import planStore from "features/Planner/data/planStore";
 import LibraryStore from "../../RecipeLibrary/data/LibraryStore";
 import type { RecipeFromPlanItem } from "global/types/types";
+import PlanItemStatus from "../../Planner/data/PlanItemStatus";
 
 export const recipeLoByItemLo = (
     itemLO: LoadObject<any>,
@@ -28,9 +29,20 @@ export const recipeLoByItemLo = (
             })
             .map((lo) => lo.getValueEnforcing());
     };
-    const prepRecipe = (item, rLO?: LoadObject<any>) => {
+    const prepRecipe = (
+        item,
+        rLO?: LoadObject<any>,
+        ancestorCompleting = false,
+        ancestorDeleting = false,
+    ): RecipeFromPlanItem => {
+        const completing = item._next_status === PlanItemStatus.COMPLETED;
+        const deleting = item._next_status === PlanItemStatus.DELETED;
         item = {
             ...item,
+            completing,
+            deleting,
+            ancestorCompleting,
+            ancestorDeleting,
             ingredients: computeKids(item).map((ref) => {
                 ref = {
                     ...ref,
@@ -49,11 +61,15 @@ export const recipeLoByItemLo = (
                         recurse = recurse || ing.type === "Recipe";
                     }
                 }
-                if (recurse) {
-                    const sub = prepRecipe(ref, iLO);
-                    if (subs.every((s) => s.id !== sub.id)) {
-                        subs.push(sub);
-                    }
+                if (recurse && subs.every((s) => s.id !== ref.id)) {
+                    subs.push(
+                        prepRecipe(
+                            ref,
+                            iLO,
+                            completing || ancestorCompleting,
+                            deleting || ancestorDeleting,
+                        ),
+                    );
                 }
                 return ref;
             }),

--- a/src/features/RecipeDisplay/utils/recipeLoByItemLo.ts
+++ b/src/features/RecipeDisplay/utils/recipeLoByItemLo.ts
@@ -49,7 +49,12 @@ export const recipeLoByItemLo = (
                         recurse = recurse || ing.type === "Recipe";
                     }
                 }
-                if (recurse) subs.push(prepRecipe(ref, iLO));
+                if (recurse) {
+                    const sub = prepRecipe(ref, iLO);
+                    if (subs.every((s) => s.id !== sub.id)) {
+                        subs.push(sub);
+                    }
+                }
                 return ref;
             }),
         };

--- a/src/features/RecipeLibrary/components/ItemImage.tsx
+++ b/src/features/RecipeLibrary/components/ItemImage.tsx
@@ -2,6 +2,7 @@ import { CardMedia } from "@mui/material";
 import React from "react";
 import { CommonProps } from "@mui/material/OverridableComponent";
 import { Maybe } from "graphql/jsutils/Maybe";
+import { grey } from "@mui/material/colors";
 
 interface Props extends CommonProps {
     url: string;
@@ -27,6 +28,7 @@ const ItemImage: React.FC<Props> = ({
             {...props}
             style={{
                 ...style,
+                backgroundColor: grey[100],
                 backgroundPosition: `${x == null ? 50 : x}% ${
                     y == null ? 50 : y
                 }%`,

--- a/src/global/types/types.ts
+++ b/src/global/types/types.ts
@@ -52,10 +52,17 @@ export interface Quantity {
     uomId?: number;
 }
 
-export interface RecipeFromPlanItem extends Recipe {
+export interface FromPlanItem {
+    id: BfsId;
+    completing?: boolean;
+    deleting?: boolean;
+    ancestorCompleting?: boolean;
+    ancestorDeleting?: boolean;
+}
+
+export interface RecipeFromPlanItem extends Recipe, FromPlanItem {
     subtaskIds: number[];
-    subrecipes: Recipe[];
-    libraryRecipeId?: BfsId;
+    subrecipes: RecipeFromPlanItem[];
 }
 
 export type Subrecipe = Pick<
@@ -66,7 +73,15 @@ export type Subrecipe = Pick<
     | "ingredients"
     | "directions"
     | "libraryRecipeId"
->;
+> &
+    Pick<
+        FromPlanItem,
+        | "id"
+        | "completing"
+        | "deleting"
+        | "ancestorCompleting"
+        | "ancestorDeleting"
+    >;
 
 export interface FullRecipe {
     recipe: Recipe;

--- a/src/views/common/DeleteButton.tsx
+++ b/src/views/common/DeleteButton.tsx
@@ -71,10 +71,9 @@ const DeleteButton: React.FC<DeleteButtonProps> = ({
                 open={open}
                 maxWidth="xs"
                 onClose={handleClose}
-                aria-labelledby="alert-dialog-title"
-                aria-describedby="alert-dialog-description"
+                aria-labelledby="delete-dialog-title"
             >
-                <DialogTitle id="alert-dialog-title">
+                <DialogTitle id="delete-dialog-title">
                     Irrevocably delete this {type}?
                 </DialogTitle>
                 <DialogActions>

--- a/src/views/common/icons.tsx
+++ b/src/views/common/icons.tsx
@@ -20,6 +20,7 @@ export {
     ArrowRight as CollapseIcon,
     MergeType as CombineIcon,
     Kitchen as CookIcon,
+    SoupKitchenOutlined as CookedItIcon,
     FileCopy as CopyIcon,
     DeleteForeverOutlined as DeleteIcon,
     Laptop as DesktopIcon,


### PR DESCRIPTION
When a planed recipe is open in cook view, offer an "i cooked it" button, which marks the backing plan item completed. The button is available whether the recipe is top-level, a subtask, a component, or within a bucket being cooked.

The button mostly behaves like "delete", though green. For top-level recipes (including single-recipe buckets), clicking it navigates back to the plan. The action is undo-able on the plan for the same four second duration.

Also a few bits of cleanup I came across on my journey.