### PR TITLE
include a bit of plan history on library recipe detail

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -317,6 +317,26 @@ type PlanItem implements CorePlanItem & Node {
     status: PlanItemStatus!
 }
 
+type PlannedRecipeHistory implements Node {
+    doneAt: DateTime!
+    doneDate: Date!
+    id: ID!
+    notes: String
+    """
+
+    The user who owns this history item, which may or may not be the recipe's
+    owner.
+    """
+    owner: User!
+    plannedAt: DateTime!
+    plannedDate: Date!
+    rating: Rating
+    ratingInt: PositiveInt
+    "The recipe this history item is for."
+    recipe: Recipe!
+    status: PlanItemStatus!
+}
+
 type PlannerMutation {
     "Assign a plan item to a bucket (in the same plan)."
     assignBucket(bucketId: ID!, id: ID!): PlanItem!
@@ -414,6 +434,19 @@ type Recipe implements Ingredient & Node & Owned {
     name: String!
     owner: User!
     photo: Photo
+    """
+
+    Number of times this recipe has been sent to any plan, optionally
+    filtered by the result status (only COMPLETED and DELETED make sense).
+    """
+    plannedCount(status: PlanItemStatus): Int!
+    """
+
+    History of this recipe being planned, in reverse-chronological order,
+    optionally filtered by the result status (only COMPLETED and DELETED make
+    sense). By default, only the five most recent records will be returned.
+    """
+    plannedHistory(last: NonNegativeInt = 5, status: PlanItemStatus): [PlannedRecipeHistory!]!
     """
 
     All subrecipes. Multiple layers of nested recipes are flattened, and the
@@ -563,6 +596,14 @@ enum PlanItemStatus {
     COMPLETED
     DELETED
     NEEDED
+}
+
+enum Rating {
+    FIVE_STARS
+    FOUR_STARS
+    ONE_STAR
+    THREE_STARS
+    TWO_STARS
 }
 
 enum RecognizedRangeType {

--- a/src/data/hooks/useGetFullRecipe.ts
+++ b/src/data/hooks/useGetFullRecipe.ts
@@ -37,6 +37,19 @@ query getRecipeWithEverything($id: ID!) {
       subrecipes {
         ...recipeCore
       }
+      plannedHistory {
+        id
+        plannedDate
+        doneDate
+        status
+        owner {
+          name
+          email
+          imageUrl
+        }
+        rating: ratingInt
+        notes
+      }
     }
   }
 }
@@ -81,6 +94,9 @@ function adapter(
                   })),
               }));
 
+    const planHistory =
+        !result || !result.plannedHistory ? [] : result.plannedHistory;
+
     const recipe: Recipe = {
         calories: result.calories,
         directions: result.directions || "",
@@ -100,6 +116,7 @@ function adapter(
         owner: result.owner,
         recipe,
         subrecipes,
+        planHistory,
     };
 }
 

--- a/src/features/RecipeDisplay/RecipeController.tsx
+++ b/src/features/RecipeDisplay/RecipeController.tsx
@@ -39,6 +39,7 @@ const RecipeController: React.FC<Props> = ({ match }) => {
                 <RecipeDetail
                     recipe={fullRecipe.recipe}
                     subrecipes={fullRecipe.subrecipes}
+                    planHistory={fullRecipe.planHistory}
                     mine={fullRecipe.mine}
                     owner={fullRecipe.owner}
                     showFab

--- a/src/global/types/types.ts
+++ b/src/global/types/types.ts
@@ -1,5 +1,6 @@
 import { CheckableActionType } from "util/typedAction";
 import { BfsId, UserType } from "global/types/identity";
+import { PlannedRecipeHistory, User } from "../../__generated__/graphql";
 
 type IngredientType = "Recipe" | "PantryItem";
 
@@ -83,9 +84,18 @@ export type Subrecipe = Pick<
         | "ancestorDeleting"
     >;
 
+export type RecipeHistory = Pick<
+    PlannedRecipeHistory,
+    "id" | "status" | "plannedDate" | "doneDate" | "notes"
+> & {
+    rating: number;
+    owner: Pick<User, "name" | "email" | "imageUrl">;
+};
+
 export interface FullRecipe {
     recipe: Recipe;
     subrecipes: Subrecipe[];
+    planHistory: RecipeHistory[];
     mine: boolean;
     owner: Omit<UserType, "provider" | "roles">;
 }


### PR DESCRIPTION
The most minimal of plan history, presented on library recipe detail:

<img width="1135" alt="image" src="https://github.com/folded-ear/gobrennas-client/assets/82654/3d5020f1-ee3f-4cf3-8a72-efdb611a6d97">

Depends on folded-ear/gobrennas-api#57
