### PR TITLE
Set recipe photos from card and detail via graphql

### DIFF
--- a/src/data/RecipeActions.js
+++ b/src/data/RecipeActions.js
@@ -1,12 +1,6 @@
 import PropTypes from "prop-types";
 import typedAction from "util/typedAction";
 
-const dissectionComponentType = PropTypes.shape({
-    start: PropTypes.number.isRequired,
-    end: PropTypes.number.isRequired,
-    text: PropTypes.string.isRequired,
-});
-
 const sendToPlanShape = {
     recipeId: PropTypes.number.isRequired,
     planId: PropTypes.number.isRequired,
@@ -14,46 +8,7 @@ const sendToPlanShape = {
 };
 
 const RecipeActions = {
-    CREATE_RECIPE: "recipe/create-recipe",
-    RECIPE_CREATED: "recipe/recipe-created",
-    CANCEL_ADD: typedAction("recipe/cancel-add", {
-        sourceId: PropTypes.number,
-    }),
-    UPDATE_RECIPE: "recipe/update-recipe",
-    SET_RECIPE_PHOTO: "recipe/set-recipe-photo",
-    RECIPE_UPDATED: "recipe/recipe-updated",
-    CANCEL_EDIT: typedAction("recipe/cancel-edit", {
-        id: PropTypes.number.isRequired,
-    }),
     RECIPE_DELETED: "recipe/recipe-deleted",
-    LOAD_EMPTY_RECIPE: "recipe/load-empty-recipe",
-    LOAD_RECIPE_DRAFT: "recipe/load-recipe/draft",
-    DRAFT_RECIPE_UPDATED: "recipe/draft-recipe-updated",
-    DRAFT_LABEL_UPDATED: "recipe/draft-label-updated",
-    DRAFT_RECIPE_INGREDIENT_MOVED: "recipe/draft-recipe-ingredient-moved",
-    SAVE_DRAFT_RECIPE: "recipe/save-draft-recipe",
-    RAW_INGREDIENT_DISSECTED: typedAction("recipe/raw-ingredient-dissected", {
-        recipeId: PropTypes.number.isRequired,
-        raw: PropTypes.string.isRequired,
-        prep: PropTypes.string,
-        quantity: dissectionComponentType,
-        units: dissectionComponentType,
-        name: dissectionComponentType.isRequired,
-    }),
-    NEW_DRAFT_INGREDIENT_YO: "recipe/new-draft-ingredient-yo",
-    KILL_DRAFT_INGREDIENT_YO: "recipe/kill-draft-ingredient-yo",
-    MULTI_LINE_DRAFT_INGREDIENT_PASTE_YO:
-        "recipe/multi-line-draft-ingredient-paste-yo",
-
-    LABEL_ADDED: typedAction("recipe/label-added", {
-        id: PropTypes.number.isRequired,
-        label: PropTypes.string.isRequired,
-    }),
-    LABEL_REMOVED: typedAction("recipe/label-removed", {
-        id: PropTypes.number.isRequired,
-        label: PropTypes.string.isRequired,
-    }),
-    LABELS_UPDATED: "recipe/labels-updated",
     SEND_TO_PLAN: typedAction("recipe/send-to-plan", sendToPlanShape),
     SENT_TO_PLAN: typedAction("recipe/sent-to-plan", sendToPlanShape),
     ERROR_SENDING_TO_PLAN: typedAction(

--- a/src/data/RecipeApi.js
+++ b/src/data/RecipeApi.js
@@ -1,7 +1,6 @@
 import BaseAxios from "axios";
 import queryClient from "data/queryClient";
 import promiseFlux from "util/promiseFlux";
-import promiseWellSizedFile from "util/promiseWellSizedFile";
 import { API_BASE_URL } from "../constants/index";
 import RecipeActions from "./RecipeActions";
 
@@ -9,76 +8,7 @@ const axios = BaseAxios.create({
     baseURL: `${API_BASE_URL}/api`,
 });
 
-function build(recipe) {
-    let recipeData = new FormData();
-    const info = { ...recipe };
-    delete info.photo;
-    recipeData.append("info", JSON.stringify(info));
-    if (recipe.photo) {
-        recipeData.append("photo", recipe.photo);
-    }
-    return recipeData;
-}
-
 const RecipeApi = {
-    addRecipe(recipe) {
-        const id = recipe.id;
-        delete recipe.id;
-        promiseFlux(
-            promiseWellSizedFile(recipe.photo).then((photo) =>
-                axios.post(
-                    "/recipe",
-                    build({
-                        ...recipe,
-                        photo,
-                    }),
-                ),
-            ),
-            (data) => ({
-                type: RecipeActions.RECIPE_CREATED,
-                id, // need this for translation
-                data: data.data,
-            }),
-        );
-    },
-
-    updateRecipe(recipe) {
-        promiseFlux(
-            promiseWellSizedFile(recipe.photo).then((photo) =>
-                axios.put(
-                    `/recipe/${recipe.id}`,
-                    build({
-                        ...recipe,
-                        photo,
-                    }),
-                ),
-            ),
-            (data) => ({
-                type: RecipeActions.RECIPE_UPDATED,
-                id: recipe.id,
-                data: data.data,
-            }),
-        );
-    },
-
-    setRecipePhoto(id, photo) {
-        if (!(photo instanceof File)) {
-            throw new Error("Non-File photo? Huh?");
-        }
-        promiseFlux(
-            promiseWellSizedFile(photo).then((p) => {
-                let payload = new FormData();
-                payload.append("photo", p);
-                return axios.put(`/recipe/${id}/photo`, payload);
-            }),
-            (data) => ({
-                type: RecipeActions.RECIPE_UPDATED,
-                id,
-                data: data.data,
-            }),
-        );
-    },
-
     deleteRecipe(id) {
         promiseFlux(axios.delete(`/recipe/${id}`), () => ({
             type: RecipeActions.RECIPE_DELETED,
@@ -105,41 +35,6 @@ const RecipeApi = {
             }),
         ).finally(() =>
             queryClient.invalidateQueries(["plan", planId, "items"]),
-        );
-    },
-
-    updateLabels(recipeId, labels) {
-        promiseFlux(
-            axios.post(`/recipe/${recipeId}/update_labels`, labels),
-            () => ({
-                type: RecipeActions.LABELS_UPDATED,
-                recipeId,
-                labels,
-            }),
-        );
-    },
-
-    addLabel(id, label) {
-        promiseFlux(
-            // this endpoint wants a plain-text post body containing the label
-            axios.post(`/recipe/${id}/labels`, label, {
-                headers: { "Content-Type": "text/plain" },
-            }),
-            () => ({
-                type: RecipeActions.LABEL_ADDED,
-                id,
-                label,
-            }),
-        );
-    },
-    removeLabel(id, label) {
-        promiseFlux(
-            axios.delete(`/recipe/${id}/labels/${encodeURIComponent(label)}`),
-            () => ({
-                type: RecipeActions.LABEL_REMOVED,
-                id,
-                label,
-            }),
         );
     },
 };

--- a/src/features/RecipeLibrary/components/ItemImageUpload.tsx
+++ b/src/features/RecipeLibrary/components/ItemImageUpload.tsx
@@ -1,9 +1,23 @@
 import { makeStyles } from "@mui/styles";
-import Dispatcher from "data/dispatcher";
-import RecipeActions from "data/RecipeActions";
 import React from "react";
 import ImageDropZone from "util/ImageDropZone";
 import { BfsId } from "global/types/identity";
+import { gql } from "../../../__generated__";
+import { useMutation } from "@apollo/client";
+import promiseWellSizedFile from "../../../util/promiseWellSizedFile";
+
+const SET_RECIPE_PHOTO = gql(`
+mutation setRecipePhoto($id: ID!, $photo: Upload!) {
+  library {
+    setRecipePhoto(id: $id, photo: $photo) {
+      id
+      photo {
+        url
+        focus
+      }
+    }
+  }
+}`);
 
 const useStyles = makeStyles({
     root: {
@@ -22,17 +36,24 @@ interface Props {
 
 const ItemImageUpload: React.FC<Props> = ({ recipeId, disabled }) => {
     const classes = useStyles();
+    const [setRecipePhoto] = useMutation(SET_RECIPE_PHOTO);
+    const handlePhoto = async (photo) => {
+        if (!(photo instanceof File)) {
+            throw new Error("Non-File photo? Huh?");
+        }
+        photo = await promiseWellSizedFile(photo);
+        setRecipePhoto({
+            variables: {
+                id: "" + recipeId,
+                photo,
+            },
+        });
+    };
     return (
         <ImageDropZone
             disabled={disabled}
             className={classes.root}
-            onImage={(file) =>
-                Dispatcher.dispatch({
-                    type: RecipeActions.SET_RECIPE_PHOTO,
-                    id: recipeId,
-                    photo: file,
-                })
-            }
+            onImage={handlePhoto}
         />
     );
 };

--- a/src/features/RecipeLibrary/data/LibraryStore.js
+++ b/src/features/RecipeLibrary/data/LibraryStore.js
@@ -47,47 +47,6 @@ class LibraryStore extends ReduceStore {
                 };
             }
 
-            case RecipeActions.CREATE_RECIPE: {
-                return {
-                    ...state,
-                    byId: state.byId.set(
-                        action.data.id,
-                        LoadObject.withValue(action.data).creating(),
-                    ),
-                };
-            }
-
-            case RecipeActions.RECIPE_CREATED: {
-                return {
-                    ...state,
-                    byId: state.byId
-                        .set(
-                            action.data.id,
-                            LoadObject.withValue(adaptTime(action.data)),
-                        )
-                        .delete(action.id),
-                };
-            }
-
-            case RecipeActions.UPDATE_RECIPE: {
-                return {
-                    ...state,
-                    byId: state.byId.update(action.data.id, (lo) =>
-                        lo.updating(),
-                    ),
-                };
-            }
-
-            case RecipeActions.RECIPE_UPDATED: {
-                return {
-                    ...state,
-                    byId: state.byId.set(
-                        action.id,
-                        LoadObject.withValue(adaptTime(action.data)).done(),
-                    ),
-                };
-            }
-
             case LibraryActions.LOAD_INGREDIENTS: {
                 if (action.ids.length === 0) {
                     return state;
@@ -134,26 +93,6 @@ class LibraryStore extends ReduceStore {
                 };
             }
 
-            case LibraryActions.SEARCH_LOADED: {
-                if (
-                    action.filter !== state.filter ||
-                    action.scope !== state.scope
-                ) {
-                    // out of order
-                    // eslint-disable-next-line no-console
-                    console.log("OUT OF ORDER - IGNORE", action.filter);
-                    return state;
-                }
-                return {
-                    ...state,
-                    byId: action.data.content.reduce(
-                        (byId, r) =>
-                            byId.set(r.id, LoadObject.withValue(adaptTime(r))),
-                        state.byId,
-                    ),
-                };
-            }
-
             case RecipeActions.SEND_TO_PLAN: {
                 RecipeApi.sendToPlan(
                     action.recipeId,
@@ -183,13 +122,6 @@ class LibraryStore extends ReduceStore {
                         })),
                     ),
                 };
-            }
-
-            // This takes place in ad hoc fashion, outside the normal edit flows
-            // which uses DraftRecipeStore. So it's here.
-            case RecipeActions.SET_RECIPE_PHOTO: {
-                RecipeApi.setRecipePhoto(action.id, action.photo);
-                return state;
             }
 
             default: {


### PR DESCRIPTION
When setting a recipe's photo from its card or detail view, use GraphQL to save it to the server instead of REST, so Apollo's cache gets updated by the response.

Fixes #137