### PR TITLE
use cache-and-network policy for search queries

### DIFF
--- a/src/data/hooks/usePantryItemSearch.ts
+++ b/src/data/hooks/usePantryItemSearch.ts
@@ -84,6 +84,7 @@ export const usePantryItemSearch = ({
     // grid, and manually encode an offset-cursor as needed.
     const after = page === 0 ? null : btoa("offset-" + (page * pageSize - 1));
     return useAdaptingQuery(SEARCH_PANTRY_ITEMS_QUERY, adapter, {
+        fetchPolicy: "cache-and-network",
         variables: { query, first: pageSize, after, sortBy, sortDir },
         skip: pageSize <= 0,
     });

--- a/src/data/hooks/usePantryItemUses.ts
+++ b/src/data/hooks/usePantryItemUses.ts
@@ -56,8 +56,7 @@ export const usePantryItemUses = (
     id: string,
 ): UseQueryResult<Results, Variables> => {
     return useAdaptingQuery(PANTRY_ITEMS_USES, adapter, {
+        fetchPolicy: "cache-and-network",
         variables: { id },
-        // This is required to make Apollo refetch when 'id' changes.
-        fetchPolicy: "network-only",
     });
 };

--- a/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
+++ b/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
@@ -23,6 +23,7 @@ export const useSearchLibrary = ({
         GetSearchLibraryQuery,
         GetSearchLibraryQueryVariables
     >(SEARCH_RECIPES, {
+        fetchPolicy: "cache-and-network",
         variables: {
             query,
             scope,


### PR DESCRIPTION
Library, pantry item, and pantry item uses search queries now all use the `cache-and-network` policy.

fixes #136