### PR TITLE
Delete recipe graphql

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -235,7 +235,7 @@ type PantryMutation {
     """
     combineItems(ids: [ID!]!): PantryItem
     "Delete a pantry item, which MUST be unreferenced."
-    deleteItem(id: ID!): Boolean!
+    deleteItem(id: ID!): Deletion!
     removeLabel(id: ID!, label: String!): PantryItem
     removeSynonym(id: ID!, synonym: String!): PantryItem
     renameItem(id: ID!, name: String!): PantryItem
@@ -357,17 +357,11 @@ type PlannerMutation {
     "Create a new empty plan."
     createPlan(name: String!): Plan!
     "Delete a bucket from a plan."
-    deleteBucket(bucketId: ID!, planId: ID!): Plan!
-    "Deletes the grant for a user w/in a plan, if one exists."
-    deleteGrant(planId: ID!, userId: ID!): Plan!
-    """
-
-    Deletes an item from a plan, and return its former parent (plan or item).
-    This operation cascades.
-    """
-    deleteItem(id: ID!): PlanItem
+    deleteBucket(bucketId: ID!, planId: ID!): Deletion!
+    "Deletes an item from a plan. This operation cascades."
+    deleteItem(id: ID!): Deletion!
     "Deletes the given plan, and all its related data."
-    deletePlan(id: ID!): Boolean!
+    deletePlan(id: ID!): Deletion!
     "Create a new plan by duplicating the specified source plan."
     duplicatePlan(name: String!, sourcePlanId: ID!): Plan!
     """
@@ -386,6 +380,8 @@ type PlannerMutation {
     under this item.
     """
     reorderSubitems(itemIds: [ID!]!, parentId: ID!): PlanItem
+    "Revokes the grant for a user w/in a plan, if one exists."
+    revokeGrant(planId: ID!, userId: ID!): Plan!
     "Set the access level granted to a user w/in a plan."
     setGrant(accessLevel: AccessLevel, planId: ID!, userId: ID!): Plan!
     """
@@ -553,7 +549,7 @@ type TimerMutation {
     Ensure the specified timer has been deleted, regardless of its status or
     existence, returning whether any action was taken.
     """
-    delete(id: ID!): Boolean!
+    delete(id: ID!): Deletion!
     "Pause the specified running timer."
     pause(id: ID!): Timer!
     "Resume the specified paused timer."

--- a/schema.graphql
+++ b/schema.graphql
@@ -46,6 +46,11 @@ type AccessControlEntry {
     user: User
 }
 
+type Deletion {
+    id: ID!
+    name: String
+}
+
 type Favorite implements Node {
     id: ID!
     "The name/title of the object that is a favorite."
@@ -100,7 +105,7 @@ type LabelsQuery {
 
 type LibraryMutation {
     createRecipe(cookThis: Boolean, info: IngredientInfo!, photo: Upload): Recipe!
-    deleteRecipe(id: ID!): Boolean!
+    deleteRecipe(id: ID!): Deletion!
     setRecipePhoto(id: ID!, photo: Upload!): Recipe!
     updateRecipe(id: ID!, info: IngredientInfo!, photo: Upload): Recipe!
 }

--- a/src/data/hooks/useDeletePantryItem.ts
+++ b/src/data/hooks/useDeletePantryItem.ts
@@ -7,7 +7,9 @@ import throwAnyGraphQLErrors from "../../util/throwAnyGraphQLErrors";
 const DELETE_PANTRY_ITEM = gql(`
 mutation deletePantryItem($id: ID!) {
   pantry {
-    deleteItem(id: $id)
+    deleteItem(id: $id) {
+      id
+    }
   }
 }`);
 
@@ -15,7 +17,12 @@ export const useDeletePantryItem = (): [
     (id: string) => Promise<boolean>,
     MutationResult<DeletePantryItemMutation>,
 ] => {
-    const [mutateFunction, out] = useMutation(DELETE_PANTRY_ITEM);
+    const [mutateFunction, out] = useMutation(DELETE_PANTRY_ITEM, {
+        update(cache, r) {
+            const id = r.data?.pantry?.deleteItem.id;
+            cache.evict({ id });
+        },
+    });
 
     const deleteItem = useCallback(
         (id) =>

--- a/src/data/hooks/useDeleteRecipe.ts
+++ b/src/data/hooks/useDeleteRecipe.ts
@@ -1,0 +1,42 @@
+import { gql } from "../../__generated__";
+import { MutationResult, useMutation } from "@apollo/client";
+import { useCallback } from "react";
+import {
+    DeleteRecipeMutation,
+    GetSearchLibraryDocument,
+} from "../../__generated__/graphql";
+import throwAnyGraphQLErrors from "../../util/throwAnyGraphQLErrors";
+import { BfsId } from "../../global/types/identity";
+
+const DELETE_RECIPE = gql(`
+mutation deleteRecipe($id: ID!) {
+  library {
+    deleteRecipe(id: $id) {
+      id
+    }
+  }
+}`);
+
+export const useDeleteRecipe = (): [
+    (id: BfsId) => Promise<boolean>,
+    MutationResult<DeleteRecipeMutation>,
+] => {
+    const [mutateFunction, out] = useMutation(DELETE_RECIPE, {
+        refetchQueries: [GetSearchLibraryDocument],
+        update(cache, r) {
+            const id = r.data?.library?.deleteRecipe.id;
+            cache.evict({ id });
+        },
+    });
+
+    const deleteRecipe = useCallback(
+        (id) =>
+            mutateFunction({ variables: { id } }).then(({ errors }) => {
+                throwAnyGraphQLErrors(errors);
+                return true;
+            }),
+        [mutateFunction],
+    );
+
+    return [deleteRecipe, out];
+};

--- a/src/features/RecipeDisplay/RecipeController.tsx
+++ b/src/features/RecipeDisplay/RecipeController.tsx
@@ -10,8 +10,8 @@ import ShareRecipe from "./components/ShareRecipe";
 import CloseButton from "../../views/common/CloseButton";
 import EditButton from "../../views/common/EditButton";
 import DeleteButton from "../../views/common/DeleteButton";
-import RecipeApi from "../../data/RecipeApi";
 import NotFound from "../../views/common/NotFound";
+import { useDeleteRecipe } from "../../data/hooks/useDeleteRecipe";
 
 type Props = RouteComponentProps<{
     id: string;
@@ -23,6 +23,7 @@ const RecipeController: React.FC<Props> = ({ match }) => {
         error,
         data: fullRecipe,
     } = useGetFullRecipe(match.params.id);
+    const [deleteRecipe] = useDeleteRecipe();
 
     if (loading) {
         return <LoadingIndicator />;
@@ -31,6 +32,12 @@ const RecipeController: React.FC<Props> = ({ match }) => {
     if (error) {
         return <NotFound />;
     }
+
+    const handleDelete = () =>
+        fullRecipe?.recipe &&
+        deleteRecipe(fullRecipe.recipe.id).then((result) => {
+            if (result) history.push("/library");
+        });
 
     return (
         fullRecipe &&
@@ -70,11 +77,7 @@ const RecipeController: React.FC<Props> = ({ match }) => {
                             {fullRecipe.mine && (
                                 <DeleteButton
                                     forType="recipe"
-                                    onConfirm={() =>
-                                        RecipeApi.deleteRecipe(
-                                            fullRecipe.recipe.id,
-                                        )
-                                    }
+                                    onConfirm={handleDelete}
                                 />
                             )}
                             <CloseButton onClick={() => history.goBack()} />

--- a/src/features/RecipeDisplay/components/ShareRecipe.tsx
+++ b/src/features/RecipeDisplay/components/ShareRecipe.tsx
@@ -17,17 +17,13 @@ type ShareRecipeProps = {
 
 const Body: React.FC<ShareRecipeProps> = ({ recipe }) => {
     const [rlo, setRlo] = React.useState<RippedLO<SharedRecipe>>({});
+    const [retry, setRetry] = React.useState(0);
     React.useEffect(() => {
-        if (rlo.data && rlo.data.id === recipe.id) {
+        if (rlo.data?.id === recipe.id) {
             return;
         }
         setRlo({
             loading: true,
-            data: {
-                id: recipe.id,
-                slug: "",
-                secret: "",
-            },
         });
         axios.get(`/${recipe.id}/share`).then(
             (data) =>
@@ -39,21 +35,23 @@ const Body: React.FC<ShareRecipeProps> = ({ recipe }) => {
                     error,
                 }),
         );
-    }, [rlo, recipe.id]);
-    if (rlo.loading || !rlo.data) {
-        return (
-            <Box style={{ textAlign: "center" }}>
-                <CircularProgress />
-            </Box>
-        );
-    } else if (rlo.error) {
+    }, [rlo.data?.id, recipe.id, retry]);
+    if (rlo.error && !rlo.loading) {
         return (
             <div>
                 Something went wrong getting a sharable link.
                 <div style={{ textAlign: "right" }}>
-                    <Button onClick={() => setRlo({})}>Try Again</Button>
+                    <Button onClick={() => setRetry((r) => r + 1)}>
+                        Try Again
+                    </Button>
                 </div>
             </div>
+        );
+    } else if (rlo.loading || !rlo.data) {
+        return (
+            <Box style={{ textAlign: "center" }}>
+                <CircularProgress />
+            </Box>
         );
     } else {
         // got it!

--- a/src/features/RecipeEdit/RecipeEditController.tsx
+++ b/src/features/RecipeEdit/RecipeEditController.tsx
@@ -6,12 +6,12 @@ import { useGetRecipe } from "data/hooks/useGetRecipe";
 import PageBody from "views/common/PageBody";
 import RecipeForm from "features/RecipeEdit/components/RecipeForm";
 import DeleteButton from "views/common/DeleteButton";
-import RecipeApi from "data/RecipeApi";
 import { Alert, CircularProgress } from "@mui/material";
 import { useUpdateRecipe } from "data/hooks/useUpdateRecipe";
 import { useCreateRecipe } from "data/hooks/useCreateRecipe";
 import type { BfsId } from "global/types/identity";
-import type { DraftRecipe, Recipe } from "global/types/types";
+import type { DraftRecipe } from "global/types/types";
+import { useDeleteRecipe } from "../../data/hooks/useDeleteRecipe";
 
 type Props = RouteComponentProps<{ id?: string }>;
 
@@ -22,7 +22,7 @@ const RecipeEditController: React.FC<Props> = ({ match }) => {
     const { data: labelList } = useGetAllLabels();
     const { error: updateError, updateRecipe } = useUpdateRecipe();
     const { error: createError, createRecipe } = useCreateRecipe();
-    let draft: Recipe;
+    const [deleteRecipe] = useDeleteRecipe();
 
     if (!id) {
         return <Redirect to="/library" />;
@@ -34,9 +34,9 @@ const RecipeEditController: React.FC<Props> = ({ match }) => {
 
     const shouldCreateCopy = match.path.split("/").includes("make-copy");
 
-    draft = { ...recipe };
+    const draft = { ...recipe };
     if (shouldCreateCopy) {
-        draft = { ...recipe, name: `Copy of ${recipe.name}` };
+        draft.name = `Copy of ${draft.name}`;
     }
 
     const handleUpdate = (recipe: DraftRecipe) => {
@@ -55,7 +55,9 @@ const RecipeEditController: React.FC<Props> = ({ match }) => {
     };
 
     const handleDelete = (id: BfsId) => {
-        RecipeApi.deleteRecipe(id);
+        deleteRecipe(id).then((result) => {
+            if (result) history.push("/library");
+        });
     };
 
     const handleCancel = () => {

--- a/src/features/Timers/data/queries.js
+++ b/src/features/Timers/data/queries.js
@@ -146,7 +146,9 @@ export const useAddTimeToTimer = (options) =>
 const DELETE_TIMER = gql`
     mutation deleteTimer($id: ID!) {
         timer {
-            delete(id: $id)
+            delete(id: $id) {
+                id
+            }
         }
     }
 `;
@@ -161,13 +163,19 @@ export const useDeleteTimer = (options) =>
                     id,
                 },
                 refetchQueries: ["listAllTimers"],
+                update(cache, r) {
+                    const id = r.data?.timer?.delete.id;
+                    cache.evict({ id });
+                },
             }),
     );
 
 const RESET_TIMER = gql`
     mutation resetTimer($id: ID!, $duration: PositiveInt!) {
         timer {
-            delete(id: $id)
+            delete(id: $id) {
+                id
+            }
             create(duration: $duration) {
                 id
             }
@@ -186,5 +194,9 @@ export const useResetTimer = (options) =>
                     duration,
                 },
                 refetchQueries: ["listAllTimers"],
+                update(cache, r) {
+                    const id = r.data?.timer?.delete.id;
+                    cache.evict({ id });
+                },
             }),
     );


### PR DESCRIPTION
delete recipes via graphql, and add cache eviction of deleted pantry items and timers.

Depends on the schema changes in folded-ear/gobrennas-api#59