### PR TITLE
Fewer numeric ids

### DIFF
--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -35,32 +35,13 @@ if (process.env.NODE_ENV === "development") {
     }
 }
 
-const ensureInt = (id: BfsId) => {
-    if (typeof id == "number") {
-        return id;
-    }
-    if (id == null) {
-        id = "";
-    } else {
-        id = id.toString();
-    }
-    let n = parseInt(id, 10);
-    if (isNaN(n) || n.toString().length !== id.length) {
-        n = parseInt(id, 36);
-    }
-    if (isNaN(n) || n.toString(36).length !== id.length) {
-        n = 0;
-        for (const codePoint of id) {
-            n *= 31;
-            n += codePoint.codePointAt(0) || 0;
-        }
-    }
-    return n;
-};
-
 export const colorHash = (id: BfsId) => {
+    let n = 0;
+    for (const codePoint of id.toString()) {
+        n *= 31;
+        n += codePoint.codePointAt(0) || 0;
+    }
     const l = planColors.length;
-    let n = ensureInt(id);
     let h = 0;
     // This XORs all the bits of the number, instead of just the last few, which
     // depends on the modulus being a power of two for a fair distribution.

--- a/src/data/ShoppingActions.js
+++ b/src/data/ShoppingActions.js
@@ -1,7 +1,11 @@
 import PlanActions from "features/Planner/data/PlanActions";
+import typedAction from "../util/typedAction";
+import PropTypes from "prop-types";
 
 const ShoppingActions = {
-    TOGGLE_PLAN: "shopping/toggle-plan",
+    TOGGLE_PLAN: typedAction("shopping/toggle-plan", {
+        id: PropTypes.number.isRequired,
+    }),
     RENAME_ITEM: PlanActions.RENAME_ITEM,
     FOCUS: "shopping/focus",
     TOGGLE_EXPANDED: "shopping/toggle-expanded",

--- a/src/data/hooks/useGetAllPlans.ts
+++ b/src/data/hooks/useGetAllPlans.ts
@@ -23,16 +23,15 @@ query getPlans {
 `);
 
 const orderComponentsById = (plans: Plan[], userId: BfsId) => {
-    return plans.reduce((byId, plan) => {
-        let ownerId = ensureInt(plan.owner.id) || Number.MAX_SAFE_INTEGER;
-        const ownerName = plan.owner.name || "";
-
-        if (ownerId === userId) {
-            ownerId = -1;
-        }
-        byId[plan.id] = [ownerId, ownerName, plan.name];
-        return byId;
-    }, {});
+    const byId = {};
+    for (const plan of plans) {
+        const ownerName =
+            plan.owner.id.toString() === userId.toString()
+                ? "" // me first!
+                : plan.owner.name || "\u7fff";
+        byId[plan.id] = [ownerName, plan.name];
+    }
+    return byId;
 };
 
 const adapter = (data?: GetPlansQuery): Plan[] => {

--- a/src/features/Navigation/NavigationController.tsx
+++ b/src/features/Navigation/NavigationController.tsx
@@ -21,20 +21,21 @@ import PlanActions from "../Planner/data/PlanActions";
 import useIsNavCollapsed, {
     setNavCollapsed,
 } from "../../data/useIsNavCollapsed";
+import { BfsId } from "../../global/types/identity";
 
 type NavigationControllerProps = {
     authenticated: boolean;
     children?: ReactNode;
 };
 
-export function toggleShoppingPlan(id) {
+export function toggleShoppingPlan(id: BfsId) {
     return Dispatcher.dispatch({
         type: ShoppingActions.TOGGLE_PLAN,
         id,
     });
 }
 
-export function selectPlan(id) {
+export function selectPlan(id: BfsId) {
     return Dispatcher.dispatch({
         type: PlanActions.SELECT_PLAN,
         id,

--- a/src/features/Planner/data/PlanActions.js
+++ b/src/features/Planner/data/PlanActions.js
@@ -7,7 +7,9 @@ const PlanActions = {
     FOCUS: "plan/focus",
     FOCUS_NEXT: "plan/focus-next",
     FOCUS_PREVIOUS: "plan/focus-previous",
-    SELECT_PLAN: "plan/select-plan",
+    SELECT_PLAN: typedAction("plan/select-plan", {
+        id: PropTypes.number.isRequired,
+    }),
     SELECT_NEXT: "plan/select-next",
     SELECT_PREVIOUS: "plan/select-previous",
     SELECT_TO: "plan/select-to",

--- a/src/features/RecipeDisplay/hooks/useLoadedPlan.ts
+++ b/src/features/RecipeDisplay/hooks/useLoadedPlan.ts
@@ -17,12 +17,13 @@ export const useLoadedPlan = (pid: BfsId | undefined) => {
             // The contract implies that effects trigger after the render
             // cycle completes, but doesn't guarantee it. The setTimeout
             // avoids a reentrant dispatch if the effect isn't deferred.
-            setTimeout(() =>
+            const t = setTimeout(() =>
                 Dispatcher.dispatch({
                     type: PlanActions.SELECT_PLAN,
                     id: typeof pid === "string" ? parseInt(pid, 10) : pid,
                 }),
             );
+            return () => clearTimeout(t);
         }
     }, [allPlansRlo, pid]);
 };

--- a/src/features/UserProfile/components/Developer.tsx
+++ b/src/features/UserProfile/components/Developer.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useState } from "react";
 import useIsDevMode, { setDevMode } from "data/useIsDevMode";
 import Dispatcher from "data/dispatcher";
 import UserActions from "data/UserActions";
@@ -10,6 +11,8 @@ import { Grid, Stack, ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { AutoAwesomeIcon, DesktopIcon, MobileIcon } from "views/common/icons";
 import useFluxStore from "../../../data/useFluxStore";
 import preferencesStore from "../../../data/preferencesStore";
+import { colorHash, planColors } from "../../../constants/colors";
+import Input from "@mui/material/Input";
 
 const dateTimeStamp = preval`module.exports = new Date().toISOString();`;
 
@@ -25,12 +28,31 @@ const Row: React.FC<RowProps> = ({ label, children }) => (
     </Grid>
 );
 
+interface SwatchProps {
+    color?: string;
+}
+
+const Swatch: React.FC<SwatchProps> = ({ color, children }) => (
+    <span
+        style={{
+            border: color ? undefined : "1px solid #999",
+            backgroundColor: color,
+            display: "inline-block",
+            minWidth: "1.5em",
+            minHeight: "1.5em",
+        }}
+    >
+        {children}
+    </span>
+);
+
 const DevMode: React.FC = () => {
     const windowSize = useWindowSize();
     const layout = useFluxStore(
         () => preferencesStore.getLayout(),
         [preferencesStore],
     );
+    const [toColorHash, setToColorHash] = useState("");
 
     function handleLayoutChange(e, layout) {
         if (!layout) return;
@@ -64,6 +86,23 @@ const DevMode: React.FC = () => {
                         <MobileIcon />
                     </ToggleButton>
                 </ToggleButtonGroup>
+            </Row>
+            <Row label={"Plan Colors"}>
+                {planColors.map((c) => (
+                    <Swatch key={c} color={c} />
+                ))}
+            </Row>
+            <Row label={"Color Hash"}>
+                <Swatch
+                    color={
+                        toColorHash === "" ? undefined : colorHash(toColorHash)
+                    }
+                />
+                <Input
+                    value={toColorHash}
+                    placeholder={"string to hash..."}
+                    onChange={(e) => setToColorHash(e.target.value)}
+                />
             </Row>
         </Stack>
     );

--- a/src/util/typedAction.ts
+++ b/src/util/typedAction.ts
@@ -27,6 +27,7 @@ const typedAction = (type: string, shape: object): CheckableActionType => {
                 type: PropTypes.instanceOf(String).isRequired,
             }).isRequired,
         };
+        return checkable;
     }
     return type;
 };

--- a/src/views/shop/PlanAvatar.tsx
+++ b/src/views/shop/PlanAvatar.tsx
@@ -1,0 +1,24 @@
+import { colorHash } from "../../constants/colors";
+import Avatar from "@mui/material/Avatar";
+import React, { useMemo } from "react";
+import { PlanItem } from "features/Planner/data/planStore";
+
+interface Props {
+    plan: PlanItem;
+}
+
+export default function PlanAvatar({ plan }: Props) {
+    const bgcolor = useMemo(() => colorHash(plan.id), [plan.id]);
+    return (
+        <Avatar
+            key={plan.id}
+            alt={plan.name}
+            title={plan.name}
+            sx={{
+                bgcolor,
+            }}
+        >
+            {plan.name.substring(0, 2)}
+        </Avatar>
+    );
+}

--- a/src/views/shop/ShopList.tsx
+++ b/src/views/shop/ShopList.tsx
@@ -18,13 +18,12 @@ import DragContainer, {
     DragContainerProps,
 } from "../../features/Planner/components/DragContainer";
 import { AddIcon, SweepIcon } from "views/common/icons";
-import { colorHash } from "../../constants/colors";
-import Avatar from "@mui/material/Avatar";
 import { useIsMobile } from "../../providers/IsMobile";
 import MobilePlanSelector from "./MobilePlanSelector";
 import useAllPlansRLO from "../../data/useAllPlansRLO";
 import { NavShopItem } from "../../features/Navigation/components/NavShopItem";
 import { toggleShoppingPlan } from "../../features/Navigation/NavigationController";
+import PlanAvatar from "./PlanAvatar";
 
 export enum ShopItemType {
     INGREDIENT,
@@ -146,18 +145,7 @@ const ShopList: React.FC<ShopListProps> = ({
                             <Stack direction={"row"} gap={1}>
                                 <span>Shop</span>
                                 {plans.map((p) => (
-                                    <Avatar
-                                        key={p.id}
-                                        alt={p.name}
-                                        title={p.name}
-                                        sx={{
-                                            // width: 24,
-                                            // height: 24,
-                                            bgcolor: colorHash(p.id),
-                                        }}
-                                    >
-                                        {p.name.substring(0, 2)}
-                                    </Avatar>
+                                    <PlanAvatar key={p.id} plan={p} />
                                 ))}
                             </Stack>
                         )}


### PR DESCRIPTION
Eliminate a few places where we push a `BfsId` to be a number, and instead push it to a string, since that's the long-term target.

> **NB:** this changes plans' associated colors, since they're now based on a string hash, not a numeric one.