### PR TITLE
offer 16 plan colors, instead of 8, to reduce collisions

### DIFF
--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,25 +1,24 @@
-import {
-    blue,
-    blueGrey,
-    indigo,
-    lightGreen,
-    lime,
-    purple,
-    red,
-    teal,
-} from "@mui/material/colors";
 import { BfsId } from "global/types/identity";
 
 export const planColors = [
     // ¡¡ Make sure this always has a size equal to a power of 2 !!
-    red[500],
-    purple[400],
-    indigo[900],
-    blue[300],
-    teal[300],
-    lightGreen[900],
-    lime[500],
-    blueGrey[500],
+    // generated at http://medialab.github.io/iwanthue/
+    "#cb4771",
+    "#caa29e",
+    "#783b32",
+    "#d14f32",
+    "#c9954c",
+    "#cbd152",
+    "#56713c",
+    "#6dce55",
+    "#8dd4aa",
+    "#77adc2",
+    "#6a7dc8",
+    "#3b3a41",
+    "#7145ca",
+    "#552b6b",
+    "#c583bd",
+    "#cc4ac0",
 ];
 
 if (process.env.NODE_ENV === "development") {

--- a/src/features/UserProfile/components/Developer.tsx
+++ b/src/features/UserProfile/components/Developer.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useState } from "react";
+import { HTMLProps, useState } from "react";
 import useIsDevMode, { setDevMode } from "data/useIsDevMode";
 import Dispatcher from "data/dispatcher";
 import UserActions from "data/UserActions";
@@ -7,12 +7,29 @@ import Divider from "@mui/material/Divider";
 import Switch from "@mui/material/Switch";
 import useWindowSize from "data/useWindowSize";
 import preval from "preval.macro";
-import { Grid, Stack, ToggleButton, ToggleButtonGroup } from "@mui/material";
+import {
+    Button,
+    Grid,
+    Stack,
+    ToggleButton,
+    ToggleButtonGroup,
+    Tooltip,
+} from "@mui/material";
 import { AutoAwesomeIcon, DesktopIcon, MobileIcon } from "views/common/icons";
 import useFluxStore from "../../../data/useFluxStore";
 import preferencesStore from "../../../data/preferencesStore";
 import { colorHash, planColors } from "../../../constants/colors";
 import Input from "@mui/material/Input";
+import {
+    blue,
+    blueGrey,
+    indigo,
+    lightGreen,
+    lime,
+    purple,
+    red,
+    teal,
+} from "@mui/material/colors";
 
 const dateTimeStamp = preval`module.exports = new Date().toISOString();`;
 
@@ -22,30 +39,31 @@ interface RowProps {
 const Row: React.FC<RowProps> = ({ label, children }) => (
     <Grid item>
         <Grid container alignItems={"center"} gap={1}>
-            <span>{label}:</span>
+            <span style={{ minWidth: "6em" }}>{label}:</span>
             {children}
         </Grid>
     </Grid>
 );
 
-interface SwatchProps {
+interface SwatchProps extends HTMLProps<any> {
     color?: string;
 }
 
-const Swatch: React.FC<SwatchProps> = ({ color, children }) => (
+const Swatch: React.FC<SwatchProps> = ({ color, style, ...passthrough }) => (
     <span
         style={{
-            border: color ? undefined : "1px solid #999",
+            border: color ? undefined : "1px solid #ddd",
             backgroundColor: color,
             display: "inline-block",
             minWidth: "1.5em",
             minHeight: "1.5em",
+            ...style,
         }}
-    >
-        {children}
-    </span>
+        {...passthrough}
+    />
 );
 
+const SAMPLES_PER_SWATCH = 100;
 const DevMode: React.FC = () => {
     const windowSize = useWindowSize();
     const layout = useFluxStore(
@@ -53,6 +71,7 @@ const DevMode: React.FC = () => {
         [preferencesStore],
     );
     const [toColorHash, setToColorHash] = useState("");
+    const [samples, setSamples] = useState<number[]>([]);
 
     function handleLayoutChange(e, layout) {
         if (!layout) return;
@@ -60,6 +79,18 @@ const DevMode: React.FC = () => {
             type: UserActions.SET_LAYOUT,
             layout,
         });
+    }
+
+    function handleResample() {
+        const samples = planColors.map(() => 0);
+        for (let i = planColors.length * SAMPLES_PER_SWATCH; i > 0; i--) {
+            samples[
+                planColors.indexOf(
+                    colorHash(Math.random().toString().substring(2)),
+                )
+            ] += 1;
+        }
+        setSamples(samples);
     }
 
     return (
@@ -87,10 +118,60 @@ const DevMode: React.FC = () => {
                     </ToggleButton>
                 </ToggleButtonGroup>
             </Row>
-            <Row label={"Plan Colors"}>
-                {planColors.map((c) => (
-                    <Swatch key={c} color={c} />
+            <Row label={"Old Colors"}>
+                {[
+                    // manually lined up with nearest match from the new ones
+                    undefined,
+                    undefined,
+                    undefined,
+                    red[500],
+                    undefined,
+                    lime[500],
+                    lightGreen[900],
+                    undefined,
+                    teal[300],
+                    blue[300],
+                    indigo[900],
+                    blueGrey[500],
+                    undefined,
+                    undefined,
+                    undefined,
+                    purple[400],
+                ].map((c, i) => (
+                    <Swatch key={i} color={c} />
                 ))}
+            </Row>
+            <Row label={"New Colors"}>
+                {planColors.map((c, i) => (
+                    <Swatch
+                        key={c}
+                        color={c}
+                        style={
+                            samples[i]
+                                ? {
+                                      minHeight: `${
+                                          (1.5 / SAMPLES_PER_SWATCH) *
+                                          samples[i]
+                                      }em`,
+                                  }
+                                : undefined
+                        }
+                    />
+                ))}
+                <Tooltip
+                    title={
+                        "Color hash a bunch of random strings and display the distribution via swatch heights."
+                    }
+                >
+                    <Button
+                        variant={"contained"}
+                        color={"secondary"}
+                        size={"small"}
+                        onClick={handleResample}
+                    >
+                        Resample
+                    </Button>
+                </Tooltip>
             </Row>
             <Row label={"Color Hash"}>
                 <Swatch


### PR DESCRIPTION
Rather than manually selecting from material's palette, I used http://medialab.github.io/iwanthue/ to select "distinct looking" colors. I don't know if that's actually clever or not. However, the scalable solution will be to let users choose a plan's color, rather than hashing and being stuck with collisions. So this is stopgap of hopefully high-enough quality.