### PR TITLE
don't synchronize items on unsaved plans

### DIFF
--- a/src/features/Planner/data/PlanItemSynchronizer.ts
+++ b/src/features/Planner/data/PlanItemSynchronizer.ts
@@ -2,21 +2,24 @@ import useActivePlanner from "data/useActivePlanner";
 import useActiveShoppingPlanIds from "../../../data/useActiveShoppingPlanIds";
 import { useSynchronizers } from "../../../util/useSynchronizer";
 import TaskApi from "./TaskApi";
+import ClientId from "../../../util/ClientId";
 
 function PlanItemSynchronizer() {
     let planIds = useActiveShoppingPlanIds();
     const plan = useActivePlanner().data;
-    if (plan && plan.id != null && !planIds.includes(plan.id)) {
+    if (plan?.id != null && !planIds.includes(plan.id)) {
         planIds = planIds.concat(plan.id);
     }
     useSynchronizers(
-        planIds.map((planId) => ({
-            queryKey: ["plan", planId, "items"],
-            queryFn: (ts) =>
-                planId
-                    ? TaskApi.getItemsUpdatedSince(planId, ts)
-                    : Promise.resolve(),
-        })),
+        planIds
+            .filter((id) => !ClientId.is(id))
+            .map((planId) => ({
+                queryKey: ["plan", planId, "items"],
+                queryFn: (ts) =>
+                    planId
+                        ? TaskApi.getItemsUpdatedSince(planId, ts)
+                        : Promise.resolve(),
+            })),
     );
     return null;
 }


### PR DESCRIPTION
as-yet-unsaved plans can't have any newly-modified items to sync down, so skip them completely.