### PR TITLE
Fully delete plan

### DIFF
--- a/src/data/preferencesStore.ts
+++ b/src/data/preferencesStore.ts
@@ -65,20 +65,17 @@ class PreferencesStore extends ReduceStore<State, FluxAction> {
             case UserActions.RESTORE_PREFERENCES: {
                 return Map(action.preferences);
             }
+
+            case PlanActions.SELECT_PLAN:
+            case PlanActions.PLAN_CREATED:
+            case PlanActions.DELETE_PLAN:
+            case PlanActions.PLAN_DELETED:
             case PlanActions.PLANS_LOADED: {
                 this.__dispatcher.waitFor([planStore.getDispatchToken()]);
-                const lo = planStore.getActivePlanLO();
-                return lo.hasValue()
-                    ? setPref(
-                          state,
-                          PrefNames.ACTIVE_PLAN,
-                          lo.getValueEnforcing().id,
-                      )
+                const rlo = planStore.getActivePlanRlo();
+                return rlo.data
+                    ? setPref(state, PrefNames.ACTIVE_PLAN, rlo.data.id)
                     : state;
-            }
-            case PlanActions.SELECT_PLAN:
-            case PlanActions.PLAN_CREATED: {
-                return setPref(state, PrefNames.ACTIVE_PLAN, action.id);
             }
 
             case ShoppingActions.TOGGLE_PLAN: {

--- a/src/features/Planner/data/conversion_helpers.ts
+++ b/src/features/Planner/data/conversion_helpers.ts
@@ -1,7 +1,10 @@
 import throwAnyGraphQLErrors from "util/throwAnyGraphQLErrors";
 import { ensureInt } from "global/utils";
 import { BfsId } from "../../../global/types/identity";
-import type { RenamePlanItemMutation } from "__generated__/graphql";
+import type {
+    CreatePlanMutation,
+    RenamePlanItemMutation,
+} from "__generated__/graphql";
 
 export const handleErrors = (error) => {
     throwAnyGraphQLErrors(error);
@@ -40,10 +43,13 @@ export const toRestPlanItem = (
     preparation: planItem.preparation,
 });
 
-export const toRestPlan = (plan) => ({
+export const toRestPlan = (
+    plan: NonNullable<CreatePlanMutation["planner"]>["createPlan"],
+) => ({
     id: ensureInt(plan.id),
     name: plan.name,
     acl: {
         ownerId: ensureInt(plan.owner.id),
     },
+    subtaskIds: [],
 });

--- a/src/features/Planner/data/utils.ts
+++ b/src/features/Planner/data/utils.ts
@@ -14,6 +14,7 @@ import dotProp from "dot-prop-immutable";
 import { bucketComparator } from "util/comparators";
 import preferencesStore from "data/preferencesStore";
 import { formatLocalDate, parseLocalDate } from "util/time";
+import history from "../../../util/history";
 
 export const AT_END = Math.random();
 
@@ -121,10 +122,9 @@ export const listCreated = (state, clientId, id, list) => {
 
 export const selectList = (state, id) => {
     if (state.activeListId === id) return state;
-    // // flush any yet-unsaved changes
+    // flush any yet-unsaved changes
     state = flushTasksToRename(state);
     // only valid ids, please
-    const list = taskForId(state, id);
     invariant(
         state.topLevelIds
             .getLoadObject()
@@ -132,6 +132,7 @@ export const selectList = (state, id) => {
             .some((it) => it === id),
         `Task '${id}' is not a list.`,
     );
+    const list = taskForId(state, id);
     state = {
         ...state,
         activeListId: id,
@@ -146,6 +147,7 @@ export const selectList = (state, id) => {
         state = addTask(state, id, "");
     }
     PlanApi.getDescendantsAsList(state.activeListId);
+    history.push(`/plan/${id}`);
     return state;
 };
 
@@ -852,7 +854,7 @@ export function selectDefaultList(state) {
         let activePlanId = preferencesStore.getActivePlan();
         if (listIds.find((id) => id === activePlanId) == null) {
             // auto-select the first one
-            activePlanId = listIds[0];
+            activePlanId = listIds[0]; // todo: select MY first one, if I have any
         }
         state = selectList(state, activePlanId);
     }

--- a/src/features/RecipeDisplay/hooks/useLoadedPlan.ts
+++ b/src/features/RecipeDisplay/hooks/useLoadedPlan.ts
@@ -4,6 +4,7 @@ import React from "react";
 import Dispatcher from "../../../data/dispatcher";
 import PlanActions from "features/Planner/data/PlanActions";
 import { BfsId } from "global/types/identity";
+import { ensureInt } from "../../../global/utils";
 
 export const useLoadedPlan = (pid: BfsId | undefined) => {
     // ensure it's loaded
@@ -13,17 +14,17 @@ export const useLoadedPlan = (pid: BfsId | undefined) => {
     );
     // ensure it's selected
     React.useEffect(() => {
-        if (pid != null && allPlansRlo.data) {
+        if (pid != null && allPlansRlo?.data) {
             // The contract implies that effects trigger after the render
             // cycle completes, but doesn't guarantee it. The setTimeout
             // avoids a reentrant dispatch if the effect isn't deferred.
             const t = setTimeout(() =>
                 Dispatcher.dispatch({
                     type: PlanActions.SELECT_PLAN,
-                    id: typeof pid === "string" ? parseInt(pid, 10) : pid,
+                    id: ensureInt(pid),
                 }),
             );
             return () => clearTimeout(t);
         }
-    }, [allPlansRlo, pid]);
+    }, [allPlansRlo?.data, pid]);
 };


### PR DESCRIPTION
When creating/deleting a plan, refetch the "all plans" query. When deleting, evict the deleted plan. When selecting a plan - including implicitly due to the active plan having disappeared - ensure the URL gets updated to match. This last closes #160.