### PR TITLE
each time the label list is mounted, refresh it

### DIFF
--- a/src/data/hooks/useGetAllLabels.ts
+++ b/src/data/hooks/useGetAllLabels.ts
@@ -12,7 +12,9 @@ const LIST_ALL_LABELS_QUERY = gql(`
 `);
 
 export const useGetAllLabels = () => {
-    const { loading, error, data } = useQuery(LIST_ALL_LABELS_QUERY);
+    const { loading, error, data } = useQuery(LIST_ALL_LABELS_QUERY, {
+        fetchPolicy: "cache-and-network",
+    });
     const labels = data?.labels?.all || [];
 
     return {


### PR DESCRIPTION
Go to the network when labels are needed, so they can't get stale. Only once per mount of whatever autocomplete is using them, but each mount refreshes.

Closes #123