### PR TITLE
Adapt UI to allow marking cooked recipes in the past

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -14,7 +14,12 @@ const config: CodegenConfig = {
             plugins: [],
             config: {
                 scalars: {
-                    Date: "Date",
+                    Date: "string",
+                    DateTime: "string",
+                    Long: "number",
+                    NonNegativeFloat: "number",
+                    NonNegativeInt: "number",
+                    PositiveInt: "number",
                     Upload: "File",
                 },
                 avoidOptionals: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "history": "^4.10.1",
         "immutable": "^4.0.0-rc.12",
         "invariant": "^2.2.4",
+        "luxon": "^3.4.4",
         "preval.macro": "^5.0.0",
         "prop-types": "^15.7.2",
         "qs": "^6.10.1",
@@ -58,6 +59,7 @@
         "@testing-library/jest-dom": "^5.12.0",
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
+        "@types/luxon": "^3.4.2",
         "@types/react-router-dom": "^5.3.3",
         "prettier": "3.0.3",
         "react": "^17.0.2",
@@ -8089,6 +8091,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
       "dev": true
     },
     "node_modules/@types/mime": {
@@ -20488,6 +20496,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "history": "^4.10.1",
     "immutable": "^4.0.0-rc.12",
     "invariant": "^2.2.4",
+    "luxon": "^3.4.4",
     "preval.macro": "^5.0.0",
     "prop-types": "^15.7.2",
     "qs": "^6.10.1",
@@ -77,7 +78,9 @@
     },
     "overrides": [
       {
-        "files": ["src/views/common/icons.tsx"],
+        "files": [
+          "src/views/common/icons.tsx"
+        ],
         "rules": {
           "no-restricted-imports": "off"
         }
@@ -153,6 +156,7 @@
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
+    "@types/luxon": "^3.4.2",
     "@types/react-router-dom": "^5.3.3",
     "prettier": "3.0.3",
     "react": "^17.0.2",

--- a/schema.graphql
+++ b/schema.graphql
@@ -389,7 +389,7 @@ type PlannerMutation {
     Sets the status of the given item. This will always return the updated
     item, though it may immediately moved to the trash (in the background).
     """
-    setStatus(id: ID!, status: PlanItemStatus!): PlanItem!
+    setStatus(doneAt: DateTime, id: ID!, status: PlanItemStatus!): PlanItem!
     "Update a bucket w/in a plan, by setting or clearing its name and date."
     updateBucket(bucketId: ID!, date: Date, name: String, planId: ID!): PlanBucket!
 }

--- a/src/features/Planner/components/CookedItButton.tsx
+++ b/src/features/Planner/components/CookedItButton.tsx
@@ -50,28 +50,21 @@ const CookButton: React.FC<Props> = ({ recipe, stayOnPage, ...props }) => {
 
     const cookedItOptions = React.useMemo(() => {
         const start = DateTime.now();
-        return [
-            {
-                id: 1,
-                label: "Today",
-                value: start.toJSDate(),
-            },
-            {
-                id: 2,
-                label: "Yesterday",
-                value: start.minus({ days: 1 }).toJSDate(),
-            },
-            {
-                id: 3,
-                label: "2 Days Ago",
-                value: start.minus({ days: 2 }).toJSDate(),
-            },
-            {
-                id: 4,
-                label: "3 Days Ago",
-                value: start.minus({ days: 3 }).toJSDate(),
-            },
-        ];
+        const days = [...Array(7).keys()];
+        const createLabel = (day: number) => {
+            if (day === 0) {
+                return "Today";
+            }
+            if (day === 1) {
+                return "Yesterday";
+            }
+            return day + " Days Ago";
+        };
+        return days.map((day) => ({
+            id: day,
+            label: createLabel(day),
+            value: start.minus({ days: day }).toJSDate(),
+        }));
     }, []);
 
     const text = pending ? "WAIT, NO!" : "I Cooked It!";

--- a/src/features/Planner/components/CookedItButton.tsx
+++ b/src/features/Planner/components/CookedItButton.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonProps, Tooltip } from "@mui/material";
+import { ButtonProps, Tooltip } from "@mui/material";
 import { CookedItIcon } from "views/common/icons";
 import React, { useCallback } from "react";
 import { FromPlanItem } from "../../../global/types/types";
@@ -6,6 +6,7 @@ import dispatcher from "../../../data/dispatcher";
 import PlanActions from "../data/PlanActions";
 import PlanItemStatus from "../data/PlanItemStatus";
 import history from "util/history";
+import SplitButton, { SelectOption } from "views/common/SplitButton";
 
 type Props = Omit<ButtonProps, "onClick"> & {
     recipe: FromPlanItem;
@@ -22,32 +23,47 @@ const CookButton: React.FC<Props> = ({ recipe, stayOnPage, ...props }) => {
             dispatcher.dispatch({
                 type: recipe.completing
                     ? PlanActions.UNDO_SET_STATUS
-                    : PlanActions.SET_STATUS,
+                    : PlanActions.COMPLETE_PLAN_ITEM,
                 id: recipe.id,
                 status: PlanItemStatus.COMPLETED,
+                doneAt: new Date(),
             });
             if (!stayOnPage) history.goBack();
         },
         [recipe.completing, recipe.id, stayOnPage],
     );
 
+    const handleSelect = (e, option: SelectOption) => {
+        console.log(e);
+        console.log(option);
+    };
+
+    const cookedItOptions = React.useMemo(() => {
+        return [
+            {
+                id: 1,
+                label: "Yesterday",
+                value: "2024-06-04T22:53:49.361Z",
+            },
+        ];
+    }, []);
+
     const text = pending ? "WAIT, NO!" : "I Cooked It!";
     const title = pending
         ? text
         : "Mark this cooked and remove it from the plan.";
     return (
-        <Tooltip title={title} placement="bottom">
-            <Button
+        <Tooltip title={title} placement="top">
+            <SplitButton
+                variant={pending ? "contained" : "outlined"}
                 color={"success"}
-                startIcon={<CookedItIcon />}
                 disabled={disabled}
                 onClick={handleClick}
-                variant={pending ? "contained" : "outlined"}
-                size={"small"}
-                {...props}
-            >
-                {text}
-            </Button>
+                onSelect={handleSelect}
+                startIcon={<CookedItIcon />}
+                primary={text}
+                options={cookedItOptions}
+            />
         </Tooltip>
     );
 };

--- a/src/features/Planner/components/CookedItButton.tsx
+++ b/src/features/Planner/components/CookedItButton.tsx
@@ -44,8 +44,9 @@ const CookButton: React.FC<Props> = ({ recipe, stayOnPage, ...props }) => {
                 status: PlanItemStatus.COMPLETED,
                 doneAt: option.value,
             });
+            if (!stayOnPage) history.goBack();
         },
-        [recipe.id],
+        [recipe.id, stayOnPage],
     );
 
     const cookedItOptions = React.useMemo(() => {

--- a/src/features/Planner/components/CookedItButton.tsx
+++ b/src/features/Planner/components/CookedItButton.tsx
@@ -1,5 +1,5 @@
-import { ButtonProps, Tooltip } from "@mui/material";
-import { CookedItIcon } from "views/common/icons";
+import { ButtonProps, Stack, Tooltip } from "@mui/material";
+import { CookedItIcon, HelpIcon } from "views/common/icons";
 import React, { useCallback } from "react";
 import { FromPlanItem } from "../../../global/types/types";
 import dispatcher from "../../../data/dispatcher";
@@ -7,6 +7,7 @@ import PlanActions from "../data/PlanActions";
 import PlanItemStatus from "../data/PlanItemStatus";
 import history from "util/history";
 import SplitButton, { SelectOption } from "views/common/SplitButton";
+import { DateTime } from "luxon";
 
 type Props = Omit<ButtonProps, "onClick"> & {
     recipe: FromPlanItem;
@@ -33,17 +34,42 @@ const CookButton: React.FC<Props> = ({ recipe, stayOnPage, ...props }) => {
         [recipe.completing, recipe.id, stayOnPage],
     );
 
-    const handleSelect = (e, option: SelectOption) => {
-        console.log(e);
-        console.log(option);
-    };
+    const handleSelect = React.useCallback(
+        (e, option: SelectOption<Date>) => {
+            console.log(option);
+            e.preventDefault();
+            dispatcher.dispatch({
+                type: PlanActions.COMPLETE_PLAN_ITEM,
+                id: recipe.id,
+                status: PlanItemStatus.COMPLETED,
+                doneAt: option.value,
+            });
+        },
+        [recipe.id],
+    );
 
     const cookedItOptions = React.useMemo(() => {
+        const start = DateTime.now();
         return [
             {
                 id: 1,
+                label: "Today",
+                value: start.toJSDate(),
+            },
+            {
+                id: 2,
                 label: "Yesterday",
-                value: "2024-06-04T22:53:49.361Z",
+                value: start.minus({ days: 1 }).toJSDate(),
+            },
+            {
+                id: 3,
+                label: "2 Days Ago",
+                value: start.minus({ days: 2 }).toJSDate(),
+            },
+            {
+                id: 4,
+                label: "3 Days Ago",
+                value: start.minus({ days: 3 }).toJSDate(),
             },
         ];
     }, []);
@@ -53,7 +79,13 @@ const CookButton: React.FC<Props> = ({ recipe, stayOnPage, ...props }) => {
         ? text
         : "Mark this cooked and remove it from the plan.";
     return (
-        <Tooltip title={title} placement="top">
+        <Stack
+            justifyContent="center"
+            alignItems="center"
+            direction="row"
+            spacing={1}
+            sx={{ marginRight: "20px" }}
+        >
             <SplitButton
                 variant={pending ? "contained" : "outlined"}
                 color={"success"}
@@ -64,7 +96,10 @@ const CookButton: React.FC<Props> = ({ recipe, stayOnPage, ...props }) => {
                 primary={text}
                 options={cookedItOptions}
             />
-        </Tooltip>
+            <Tooltip title={title} placement="top">
+                <HelpIcon sx={{ fontSize: 16 }} />
+            </Tooltip>
+        </Stack>
     );
 };
 

--- a/src/features/Planner/components/CookedItButton.tsx
+++ b/src/features/Planner/components/CookedItButton.tsx
@@ -36,7 +36,6 @@ const CookButton: React.FC<Props> = ({ recipe, stayOnPage, ...props }) => {
 
     const handleSelect = React.useCallback(
         (e, option: SelectOption<Date>) => {
-            console.log(option);
             e.preventDefault();
             dispatcher.dispatch({
                 type: PlanActions.COMPLETE_PLAN_ITEM,

--- a/src/features/Planner/components/PlanHeader.tsx
+++ b/src/features/Planner/components/PlanHeader.tsx
@@ -20,7 +20,7 @@ import {
     ExpandAll,
     SortByBucketIcon,
 } from "views/common/icons";
-import SplitButton from "views/common/SplitButton";
+import SplitButton, { SelectOption } from "views/common/SplitButton";
 import AddToCalendar from "./AddToCalendar";
 import CollapseIconButton from "../../../global/components/CollapseIconButton";
 import { useIsMobile } from "../../../providers/IsMobile";
@@ -88,12 +88,12 @@ function PlanHeader({
         setShowAdd(false);
     };
 
-    const onDuplicate = (e, list) => {
+    const onDuplicate = (_, plan: SelectOption) => {
         if (!isValidName(name)) return;
         Dispatcher.dispatch({
             type: PlanActions.DUPLICATE_PLAN,
             name: name.trim(),
-            fromId: list.id,
+            fromId: plan.id,
         });
         setName("");
         setShowAdd(false);

--- a/src/features/Planner/components/PlanHeader.tsx
+++ b/src/features/Planner/components/PlanHeader.tsx
@@ -88,7 +88,7 @@ function PlanHeader({
         setShowAdd(false);
     };
 
-    const onDuplicate = (_, plan: SelectOption) => {
+    const onDuplicate = (_, plan: SelectOption<never>) => {
         if (!isValidName(name)) return;
         Dispatcher.dispatch({
             type: PlanActions.DUPLICATE_PLAN,

--- a/src/features/Planner/data/PlanActions.js
+++ b/src/features/Planner/data/PlanActions.js
@@ -41,6 +41,12 @@ const PlanActions = {
         id: clientOrDatabaseIdType.isRequired,
         status: PropTypes.string.isRequired,
     }),
+    COMPLETE_PLAN_ITEM: typedAction("plan/complete-plan-item", {
+        id: clientOrDatabaseIdType.isRequired,
+        status: PropTypes.string.isRequired,
+        doneAt: PropTypes.instanceOf(Date), // can be null
+    }),
+    PLAN_ITEM_COMPLETED: "plan/plan-item-completed",
     BULK_SET_STATUS: typedAction("plan/bulk-set-status", {
         ids: PropTypes.arrayOf(clientOrDatabaseIdType).isRequired,
         status: PropTypes.string.isRequired,

--- a/src/features/Planner/data/PlanApi.ts
+++ b/src/features/Planner/data/PlanApi.ts
@@ -88,6 +88,7 @@ const PlanApi = {
                 },
             }),
             (result: FetchResult<SetStatusMutation>) => {
+                // TODO: Apollo cache needs to be updated, and is not yet
                 const id = result?.data?.planner?.setStatus?.id || null;
                 return (
                     id && {

--- a/src/features/Planner/data/PlanApi.ts
+++ b/src/features/Planner/data/PlanApi.ts
@@ -4,6 +4,7 @@ import promiseFlux from "util/promiseFlux";
 import PlanActions from "./PlanActions";
 import { client } from "providers/ApolloClient";
 import {
+    COMPLETE_PLAN_ITEM,
     CREATE_BUCKET,
     DELETE_BUCKET,
     DELETE_PLAN_ITEM,
@@ -23,6 +24,7 @@ import {
     toRestPlanItem,
 } from "features/Planner/data/conversion_helpers";
 import { ensureInt } from "global/utils";
+import { PlanItemStatus, SetStatusMutation } from "__generated__/graphql";
 
 const axios = BaseAxios.create({
     baseURL: `${API_BASE_URL}/api/plan`,
@@ -68,6 +70,28 @@ const PlanApi = {
                 return (
                     id && {
                         type: PlanActions.DELETED,
+                        id: ensureInt(id),
+                    }
+                );
+            },
+            handleErrors,
+        ),
+
+    completeItem: (id: number, doneAt: Date) =>
+        promiseFlux(
+            client.mutate({
+                mutation: COMPLETE_PLAN_ITEM,
+                variables: {
+                    id: id.toString(),
+                    status: PlanItemStatus.Completed,
+                    doneAt: doneAt?.toISOString() || null,
+                },
+            }),
+            (result: FetchResult<SetStatusMutation>) => {
+                const id = result?.data?.planner?.setStatus?.id || null;
+                return (
+                    id && {
+                        type: PlanActions.PLAN_ITEM_COMPLETED,
                         id: ensureInt(id),
                     }
                 );

--- a/src/features/Planner/data/mutations.ts
+++ b/src/features/Planner/data/mutations.ts
@@ -96,3 +96,13 @@ mutation deleteBucket($planId: ID!, $bucketId: ID!) {
   }
 }
 `);
+
+export const COMPLETE_PLAN_ITEM = gql(`
+mutation setStatus($id: ID!, $status: PlanItemStatus!, $doneAt: DateTime) {
+  planner {
+    setStatus(id: $id, status: $status, doneAt: $doneAt) {
+      id
+    }
+  }
+}
+`);

--- a/src/features/Planner/data/planStore.js
+++ b/src/features/Planner/data/planStore.js
@@ -254,6 +254,16 @@ class PlanStore extends ReduceStore {
                 return queueDelete(state, action.id);
             }
 
+            case PlanActions.COMPLETE_PLAN_ITEM: {
+                PlanApi.completeItem(action.id, action.doneAt);
+                return state;
+            }
+
+            // TODO: This is not going through the queue...YET! Will be addressed in future work
+            case PlanActions.PLAN_ITEM_COMPLETED: {
+                return taskDeleted(state, action.id);
+            }
+
             case PlanActions.SET_STATUS: {
                 return doInteractiveStatusChange(
                     state,

--- a/src/global/types/types.ts
+++ b/src/global/types/types.ts
@@ -89,7 +89,7 @@ export type RecipeHistory = Pick<
     PlannedRecipeHistory,
     "id" | "status" | "plannedDate" | "doneDate" | "notes"
 > & {
-    rating: number;
+    rating: number | null;
     owner: Pick<User, "name" | "email" | "imageUrl">;
 };
 

--- a/src/views/common/SplitButton.tsx
+++ b/src/views/common/SplitButton.tsx
@@ -1,5 +1,5 @@
 import Button from "@mui/material/Button";
-import ButtonGroup from "@mui/material/ButtonGroup";
+import ButtonGroup, { ButtonGroupOwnProps } from "@mui/material/ButtonGroup";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 import Grid from "@mui/material/Grid";
 import Grow from "@mui/material/Grow";
@@ -7,10 +7,10 @@ import MenuItem from "@mui/material/MenuItem";
 import MenuList from "@mui/material/MenuList";
 import Popper from "@mui/material/Popper";
 import { makeStyles } from "@mui/styles";
-import { DropDownIcon } from "views/common/icons";
+import { CookedItIcon, DropDownIcon } from "views/common/icons";
 import React, { MouseEventHandler, ReactNode } from "react";
 import { BfsId } from "global/types/identity";
-import { Paper } from "@mui/material";
+import { ButtonProps, Color, Paper } from "@mui/material";
 
 const useStyles = makeStyles({
     popper: {
@@ -18,22 +18,22 @@ const useStyles = makeStyles({
     },
 });
 
-interface Option {
+export type SelectOption = {
     id: BfsId;
     label: string;
-}
+    value?: string | null;
+};
 
 interface Props {
     primary: ReactNode;
-
     onClick: MouseEventHandler;
-
-    options: Option[];
-
-    onSelect(event: Event, opt: Option): void;
-
+    options: SelectOption[];
+    onSelect(event: Event, opt: SelectOption): void;
     disabled?: boolean;
     dropdownDisabled?: boolean;
+    variant?: ButtonGroupOwnProps["variant"];
+    color?: ButtonGroupOwnProps["color"];
+    startIcon?: ReactNode;
 }
 
 const SplitButton: React.FC<Props> = ({
@@ -43,6 +43,9 @@ const SplitButton: React.FC<Props> = ({
     options,
     disabled = false,
     dropdownDisabled = disabled,
+    variant = "contained",
+    color = "primary",
+    startIcon,
 }) => {
     const classes = useStyles();
     const [open, setOpen] = React.useState(false);
@@ -74,11 +77,13 @@ const SplitButton: React.FC<Props> = ({
         <Grid container direction="column" alignItems="center">
             <Grid item xs={12}>
                 <ButtonGroup
-                    variant="contained"
+                    variant={variant}
                     ref={anchorRef}
                     aria-label="split button"
+                    color={color}
                 >
                     <Button
+                        startIcon={startIcon ? startIcon : null}
                         size="small"
                         onClick={handleClick}
                         disabled={disabled}

--- a/src/views/common/SplitButton.tsx
+++ b/src/views/common/SplitButton.tsx
@@ -7,10 +7,10 @@ import MenuItem from "@mui/material/MenuItem";
 import MenuList from "@mui/material/MenuList";
 import Popper from "@mui/material/Popper";
 import { makeStyles } from "@mui/styles";
-import { CookedItIcon, DropDownIcon } from "views/common/icons";
+import { DropDownIcon } from "views/common/icons";
 import React, { MouseEventHandler, ReactNode } from "react";
 import { BfsId } from "global/types/identity";
-import { ButtonProps, Color, Paper } from "@mui/material";
+import { Paper } from "@mui/material";
 
 const useStyles = makeStyles({
     popper: {
@@ -18,17 +18,17 @@ const useStyles = makeStyles({
     },
 });
 
-export type SelectOption = {
+export type SelectOption<TOption> = {
     id: BfsId;
     label: string;
-    value?: string | null;
+    value?: TOption | null;
 };
 
-interface Props {
+interface Props<TOption> {
     primary: ReactNode;
     onClick: MouseEventHandler;
-    options: SelectOption[];
-    onSelect(event: Event, opt: SelectOption): void;
+    options: SelectOption<TOption>[];
+    onSelect(event: Event, opt: SelectOption<TOption>): void;
     disabled?: boolean;
     dropdownDisabled?: boolean;
     variant?: ButtonGroupOwnProps["variant"];
@@ -36,7 +36,7 @@ interface Props {
     startIcon?: ReactNode;
 }
 
-const SplitButton: React.FC<Props> = ({
+const SplitButton = <TOption,>({
     primary,
     onClick,
     onSelect,
@@ -46,7 +46,7 @@ const SplitButton: React.FC<Props> = ({
     variant = "contained",
     color = "primary",
     startIcon,
-}) => {
+}: Props<TOption>) => {
     const classes = useStyles();
     const [open, setOpen] = React.useState(false);
     const anchorRef = React.useRef<HTMLDivElement>(null);


### PR DESCRIPTION
This PR adds the minimum required UI to allow adding a cooked this date to a planned recipe in the past, to allow for a user forgetting to mark it cooked on the day it was cooked.