### PR TITLE
nav to new plan post delete, not on every selection

### DIFF
--- a/src/features/Planner/data/planStore.js
+++ b/src/features/Planner/data/planStore.js
@@ -57,6 +57,7 @@ import {
     toggleExpanded,
     unnestTask,
 } from "./utils";
+import history from "../../../util/history";
 
 /*
  * This store is way too muddled. But leaving it that way for the moment, to
@@ -126,12 +127,18 @@ class PlanStore extends ReduceStore {
             }
 
             case PlanActions.PLAN_DELETED: {
-                return selectDefaultList({
+                // noinspection EqualityComparisonWithCoercionJS
+                const wasActive = state.activeListId == action.id; // eslint-disable-line eqeqeq
+                state = selectDefaultList({
                     ...dotProp.delete(state, ["byId", action.id]),
                     topLevelIds: state.topLevelIds.map((ids) =>
                         ids.filter((id) => id !== action.id),
                     ),
                 });
+                if (wasActive && state.activeListId) {
+                    history.push(`/plan/${state.activeListId}`);
+                }
+                return state;
             }
 
             case PlanActions.LOAD_PLANS:

--- a/src/features/Planner/data/utils.ts
+++ b/src/features/Planner/data/utils.ts
@@ -14,7 +14,6 @@ import dotProp from "dot-prop-immutable";
 import { bucketComparator } from "util/comparators";
 import preferencesStore from "data/preferencesStore";
 import { formatLocalDate, parseLocalDate } from "util/time";
-import history from "../../../util/history";
 
 export const AT_END = Math.random();
 
@@ -147,7 +146,6 @@ export const selectList = (state, id) => {
         state = addTask(state, id, "");
     }
     PlanApi.getDescendantsAsList(state.activeListId);
-    history.push(`/plan/${id}`);
     return state;
 };
 


### PR DESCRIPTION
A regression I introduce when dealing with graphql-deleted plans, where "nav to active" happens on initial load of the plan list as well.