### PR TITLE
This weeks buckets

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -357,6 +357,8 @@ type PlannerMutation {
     createPlan(name: String!, sourcePlanId: ID): Plan!
     "Delete a bucket from a plan."
     deleteBucket(bucketId: ID!, planId: ID!): Deletion!
+    "Delete multiple buckets from a single plan."
+    deleteBuckets(bucketIds: [ID!]!, planId: ID!): [Deletion!]!
     "Deletes an item from a plan. This operation cascades."
     deleteItem(id: ID!): Deletion!
     "Deletes the given plan, and all its related data."

--- a/src/features/Planner/components/PlanBucketManager.tsx
+++ b/src/features/Planner/components/PlanBucketManager.tsx
@@ -22,7 +22,7 @@ const BucketManager = () => {
     const {
         buckets,
         onBucketCreate,
-        onBucketGenerate,
+        onBucketReset,
         onBucketNameChange,
         onBucketDateChange,
         onBucketDelete,
@@ -36,9 +36,9 @@ const BucketManager = () => {
                     type: PlanActions.CREATE_BUCKET,
                     planId: plan.id,
                 }),
-            onBucketGenerate: () =>
+            onBucketReset: () =>
                 dispatcher.dispatch({
-                    type: PlanActions.GENERATE_ONE_WEEKS_BUCKETS,
+                    type: PlanActions.RESET_TO_THIS_WEEKS_BUCKETS,
                     planId: plan.id,
                 }),
             onBucketNameChange: (id, value) =>
@@ -85,12 +85,12 @@ const BucketManager = () => {
                                 </IconButton>
                             </Tooltip>
                             <Tooltip
-                                title="Generate a week's buckets"
+                                title="Reset to this week's buckets"
                                 placement="bottom-end"
                             >
                                 <IconButton
                                     edge="end"
-                                    onClick={() => onBucketGenerate()}
+                                    onClick={() => onBucketReset()}
                                     size="small"
                                 >
                                     <GenerateBucketsIcon />

--- a/src/features/Planner/components/PlanHeader.tsx
+++ b/src/features/Planner/components/PlanHeader.tsx
@@ -1,6 +1,5 @@
 import {
     Box,
-    Drawer,
     Grid,
     IconButton,
     Stack,
@@ -181,22 +180,11 @@ function PlanHeader({
                                 <AddToCalendar plan={activePlan} />
                             </>
                         )}
-                        <Drawer
+                        <PlanSidebar
                             open={planDetailVisible}
-                            anchor="right"
                             onClose={onCloseDrawer}
-                        >
-                            <div
-                                style={{
-                                    minHeight: "100%",
-                                    minWidth: "40vw",
-                                    maxWidth: "90vw",
-                                    backgroundColor: "#f7f7f7",
-                                }}
-                            >
-                                <PlanSidebar plan={activePlan} />
-                            </div>
-                        </Drawer>
+                            plan={activePlan}
+                        />
                     </Grid>
                 )}
                 <Grid item>

--- a/src/features/Planner/data/PlanActions.js
+++ b/src/features/Planner/data/PlanActions.js
@@ -66,9 +66,12 @@ const PlanActions = {
     CREATE_BUCKET: typedAction("plan/create-bucket", {
         planId: clientOrDatabaseIdType.isRequired,
     }),
-    GENERATE_ONE_WEEKS_BUCKETS: typedAction("plan/generate-one-weeks-buckets", {
-        planId: clientOrDatabaseIdType.isRequired,
-    }),
+    RESET_TO_THIS_WEEKS_BUCKETS: typedAction(
+        "plan/reset-to-this-weeks-buckets",
+        {
+            planId: clientOrDatabaseIdType.isRequired,
+        },
+    ),
     RENAME_BUCKET: typedAction("plan/rename-bucket", {
         planId: clientOrDatabaseIdType.isRequired,
         id: clientOrDatabaseIdType.isRequired,

--- a/src/features/Planner/data/PlanActions.js
+++ b/src/features/Planner/data/PlanActions.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { clientOrDatabaseIdType } from "util/ClientId";
+import ClientId, { clientOrDatabaseIdType } from "util/ClientId";
 import typedAction from "util/typedAction";
 
 const PlanActions = {
@@ -85,6 +85,7 @@ const PlanActions = {
     }),
     BUCKET_CREATED: typedAction("plan/bucket-created", {
         planId: PropTypes.number.isRequired,
+        clientId: ClientId.propType.isRequired,
         data: PropTypes.object.isRequired,
     }),
     BUCKET_UPDATED: typedAction("plan/bucket-updated", {

--- a/src/features/Planner/data/PlanApi.ts
+++ b/src/features/Planner/data/PlanApi.ts
@@ -7,6 +7,7 @@ import {
     COMPLETE_PLAN_ITEM,
     CREATE_BUCKET,
     DELETE_BUCKET,
+    DELETE_BUCKETS,
     DELETE_PLAN_ITEM,
     RENAME_PLAN_ITEM,
     UPDATE_BUCKET,
@@ -14,17 +15,20 @@ import {
 import type {
     CreateBucketMutation,
     DeleteBucketMutation,
+    DeleteBucketsMutation,
     DeletePlanItemMutation,
     RenamePlanItemMutation,
     UpdateBucketMutation,
 } from "__generated__/graphql";
+import { PlanItemStatus, SetStatusMutation } from "__generated__/graphql";
 import type { FetchResult } from "@apollo/client";
 import {
     handleErrors,
     toRestPlanItem,
 } from "features/Planner/data/conversion_helpers";
 import { ensureInt } from "global/utils";
-import { PlanItemStatus, SetStatusMutation } from "__generated__/graphql";
+import { BfsId } from "../../../global/types/identity";
+import { WireBucket } from "./planStore";
 
 const axios = BaseAxios.create({
     baseURL: `${API_BASE_URL}/api/plan`,
@@ -138,14 +142,15 @@ const PlanApi = {
             data: r.data,
         })),
 
-    createBucket: (planId: number, variables) =>
-        promiseFlux(
+    createBucket: (planId: number, bucket: WireBucket) => {
+        const clientId = bucket.id;
+        return promiseFlux(
             client.mutate({
                 mutation: CREATE_BUCKET,
                 variables: {
                     planId: planId.toString(),
-                    name: variables.name,
-                    date: variables.date,
+                    name: bucket.name,
+                    date: bucket.date,
                 },
             }),
             (result: FetchResult<CreateBucketMutation>) => {
@@ -154,6 +159,7 @@ const PlanApi = {
                     bucket && {
                         type: PlanActions.BUCKET_CREATED,
                         planId,
+                        clientId: clientId,
                         data: {
                             id: ensureInt(bucket.id),
                             name: bucket.name,
@@ -163,17 +169,18 @@ const PlanApi = {
                 );
             },
             handleErrors,
-        ),
+        );
+    },
 
-    updateBucket: (planId: number, id: number, variables) =>
+    updateBucket: (planId: number, id: BfsId, bucket: WireBucket) =>
         promiseFlux(
             client.mutate({
                 mutation: UPDATE_BUCKET,
                 variables: {
                     planId: planId.toString(),
                     bucketId: id.toString(),
-                    name: variables.name,
-                    date: variables.date,
+                    name: bucket.name,
+                    date: bucket.date,
                 },
             }),
             (result: FetchResult<UpdateBucketMutation>) => {

--- a/src/features/Planner/data/PlanApi.ts
+++ b/src/features/Planner/data/PlanApi.ts
@@ -219,6 +219,25 @@ const PlanApi = {
                 );
             },
         ),
+
+    deleteBuckets: (planId: number, ids: number[]) =>
+        promiseFlux(
+            client.mutate({
+                mutation: DELETE_BUCKETS,
+                variables: {
+                    planId: planId.toString(),
+                    bucketIds: ids.map((id) => id.toString()),
+                },
+            }),
+            (result: FetchResult<DeleteBucketsMutation>) => {
+                const dels = result?.data?.planner?.deleteBuckets || [];
+                return {
+                    type: PlanActions.BUCKETS_DELETED,
+                    planId,
+                    id: dels.map((d) => ensureInt(d.id)),
+                };
+            },
+        ),
 };
 
 export default PlanApi;

--- a/src/features/Planner/data/PlanApi.ts
+++ b/src/features/Planner/data/PlanApi.ts
@@ -220,7 +220,7 @@ const PlanApi = {
             },
         ),
 
-    deleteBuckets: (planId: number, ids: number[]) =>
+    deleteBuckets: (planId: number, ids: BfsId[]) =>
         promiseFlux(
             client.mutate({
                 mutation: DELETE_BUCKETS,

--- a/src/features/Planner/data/mutations.ts
+++ b/src/features/Planner/data/mutations.ts
@@ -97,6 +97,16 @@ mutation deleteBucket($planId: ID!, $bucketId: ID!) {
 }
 `);
 
+export const DELETE_BUCKETS = gql(`
+mutation deleteBuckets($planId: ID!, $bucketIds: [ID!]!) {
+  planner {
+    deleteBuckets(planId: $planId, bucketIds: $bucketIds) {
+      id
+    }
+  }
+}
+`);
+
 export const COMPLETE_PLAN_ITEM = gql(`
 mutation setStatus($id: ID!, $status: PlanItemStatus!, $doneAt: DateTime) {
   planner {

--- a/src/features/Planner/data/planStore.d.ts
+++ b/src/features/Planner/data/planStore.d.ts
@@ -8,8 +8,14 @@ import { RippedLO } from "../../../util/ripLoadObject";
 
 export interface PlanBucket {
     id: BfsId;
-    name?: string;
-    date?: Date;
+    name?: Maybe<string>;
+    date: Maybe<Date>;
+}
+
+export interface WireBucket {
+    id: BfsId;
+    name?: Maybe<string>;
+    date: Maybe<string>;
 }
 
 export interface PlanItem {

--- a/src/features/Planner/data/planStore.js
+++ b/src/features/Planner/data/planStore.js
@@ -43,6 +43,7 @@ import {
     queueDelete,
     queueStatusUpdate,
     renameTask,
+    resetToThisWeeksBuckets,
     saveBucket,
     selectDefaultList,
     selectDelta,
@@ -399,9 +400,9 @@ class PlanStore extends ReduceStore {
             case PlanActions.BUCKET_CREATED: {
                 return mapPlanBuckets(state, action.planId, (bs) =>
                     bs
+                        .filter((b) => b.id !== action.clientId)
                         .concat(deserializeBucket(action.data))
-                        .sort(bucketComparator)
-                        .filter((b) => !ClientId.is(b.id)),
+                        .sort(bucketComparator),
                 );
             }
 

--- a/src/features/Planner/data/planStore.js
+++ b/src/features/Planner/data/planStore.js
@@ -373,28 +373,8 @@ class PlanStore extends ReduceStore {
                 );
             }
 
-            case PlanActions.GENERATE_ONE_WEEKS_BUCKETS: {
-                return mapPlanBuckets(state, action.planId, (bs) => {
-                    const yesterday = new Date();
-                    yesterday.setDate(yesterday.getDate() - 1);
-                    const maxDate = bs.reduce(
-                        (max, b) =>
-                            b.date != null && b.date > max ? b.date : max,
-                        yesterday,
-                    );
-                    const newOnes = [];
-                    for (let i = 1; i <= 7; i++) {
-                        const date = new Date(maxDate.valueOf());
-                        date.setDate(date.getDate() + i);
-                        const b = {
-                            id: ClientId.next(),
-                            date,
-                        };
-                        saveBucket(state, b);
-                        newOnes.push(b);
-                    }
-                    return bs.concat(newOnes);
-                });
+            case PlanActions.RESET_TO_THIS_WEEKS_BUCKETS: {
+                return resetToThisWeeksBuckets(state, action.planId);
             }
 
             case PlanActions.BUCKET_CREATED: {

--- a/src/features/Planner/data/utils.ts
+++ b/src/features/Planner/data/utils.ts
@@ -888,10 +888,10 @@ export function serializeBucket(b: PlanBucket): WireBucket {
 }
 
 export const saveBucket = (state, bucket: PlanBucket) => {
-    const variables = serializeBucket(bucket);
+    const wireBucket = serializeBucket(bucket);
     ClientId.is(bucket.id)
-        ? PlanApi.createBucket(state.activeListId, variables)
-        : PlanApi.updateBucket(state.activeListId, bucket.id, variables);
+        ? PlanApi.createBucket(state.activeListId, wireBucket)
+        : PlanApi.updateBucket(state.activeListId, bucket.id, wireBucket);
 };
 
 export const doInteractiveStatusChange = (state, id, status) => {

--- a/src/features/Planner/data/utils.ts
+++ b/src/features/Planner/data/utils.ts
@@ -14,6 +14,7 @@ import dotProp from "dot-prop-immutable";
 import { bucketComparator } from "util/comparators";
 import preferencesStore from "data/preferencesStore";
 import { formatLocalDate, parseLocalDate } from "util/time";
+import { PlanBucket, WireBucket } from "./planStore";
 
 export const AT_END = Math.random();
 
@@ -878,13 +879,15 @@ export const mapPlanBuckets = (state, planId, work) =>
         })),
     );
 
-export const deserializeBucket = (b) =>
-    b.date ? { ...b, date: parseLocalDate(b.date) } : b;
+export function deserializeBucket(b: WireBucket): PlanBucket {
+    return { ...b, date: parseLocalDate(b.date) };
+}
 
-export const serializeBucket = (b) =>
-    b.date ? { ...b, date: formatLocalDate(b.date) } : b;
+export function serializeBucket(b: PlanBucket): WireBucket {
+    return { ...b, date: formatLocalDate(b.date) };
+}
 
-export const saveBucket = (state, bucket) => {
+export const saveBucket = (state, bucket: PlanBucket) => {
     const variables = serializeBucket(bucket);
     ClientId.is(bucket.id)
         ? PlanApi.createBucket(state.activeListId, variables)

--- a/src/features/Planner/data/utils.ts
+++ b/src/features/Planner/data/utils.ts
@@ -894,6 +894,31 @@ export const saveBucket = (state, bucket: PlanBucket) => {
         : PlanApi.updateBucket(state.activeListId, bucket.id, wireBucket);
 };
 
+// T should be PlanStore.TState...
+export function resetToThisWeeksBuckets<T>(state: T, planId: number): T {
+    return mapPlanBuckets(state, planId, (buckets) => {
+        if (buckets.length > 0) {
+            const ids = buckets
+                .map((b) => b.id)
+                .filter((id) => !ClientId.is(id));
+            PlanApi.deleteBuckets(planId, ids);
+        }
+        const today = new Date();
+        const newOnes: PlanBucket[] = [];
+        for (let i = 0; i < 7; i++) {
+            const date = new Date(today.valueOf());
+            date.setDate(date.getDate() + i);
+            const b = {
+                id: ClientId.next(),
+                date,
+            };
+            saveBucket(state, b);
+            newOnes.push(b);
+        }
+        return newOnes;
+    });
+}
+
 export const doInteractiveStatusChange = (state, id, status) => {
     if (willStatusDelete(status) && id === state.activeTaskId) {
         state = focusDelta(state, id, 1);

--- a/src/util/comparators.ts
+++ b/src/util/comparators.ts
@@ -1,3 +1,5 @@
+import { PlanBucket } from "../features/Planner/data/planStore";
+
 const collator = new Intl.Collator(undefined, {
     sensitivity: "base",
     ignorePunctuation: true,
@@ -26,13 +28,7 @@ interface Dated {
     date?: Date;
 }
 
-type Bucket = Named & Dated;
-
-/**
- * I am an object comparator based on the "date" and "name" keys, used for
- * sorting plan buckets.
- */
-export const bucketComparator = (a: Bucket, b: Bucket) => {
+export const byDateComparator = (a: Dated, b: Dated) => {
     const ad = a.date;
     const bd = b.date;
     if (ad != null || bd != null) {
@@ -43,7 +39,16 @@ export const bucketComparator = (a: Bucket, b: Bucket) => {
         if (ad < bd) return -1;
         if (ad > bd) return +1;
     }
-    return humanStringComparator(a.name, b.name);
+    // equal (including both null)
+    return 0;
+};
+
+/**
+ * I am an object comparator based on the "date" and "name" keys, used for
+ * sorting plan buckets.
+ */
+export const bucketComparator = (a: PlanBucket, b: PlanBucket) => {
+    return byDateComparator(a, b) || humanStringComparator(a.name, b.name);
 };
 
 /**

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -42,7 +42,7 @@ export const formatTimer = (seconds?: number) => {
 
 const TEN_YEARS_FROM_NOW_THIS_CENTURY = (new Date().getFullYear() % 100) + 10;
 
-export function parseLocalDate(date: string): Maybe<Date> {
+export function parseLocalDate(date: Maybe<string>): Maybe<Date> {
     if (!date) return null;
     if (!/^\d+-\d+-\d+(\D|$)/.test(date)) return null;
     const parts = date
@@ -70,7 +70,7 @@ function pad(number: number): string {
     return "" + number;
 }
 
-export function formatLocalDate(date?: Date): Maybe<string> {
+export function formatLocalDate(date: Maybe<Date>): Maybe<string> {
     if (!date) return null;
     return (
         date.getFullYear() +

--- a/src/views/common/icons.tsx
+++ b/src/views/common/icons.tsx
@@ -28,7 +28,7 @@ export {
     ErrorOutline as ErrorIcon,
     Star as FavoriteIcon,
     ArrowForward as ForwardIcon,
-    AddToPhotos as GenerateBucketsIcon,
+    DateRange as GenerateBucketsIcon,
     HelpOutline as HelpIcon,
     InfoOutlined as InfoIcon,
     MenuBook as LibraryIcon,


### PR DESCRIPTION
Previously, generating a week's buckets always added the "next" seven buckets, starting after all existing buckets' dates and no earlier than today. Now it will create and delete buckets so that there are exactly seven buckets, one for today and each of the next six days.

For the normal "shopping on Saturday" routine, it'll delete all existing buckets (no need to do it manually anymore!) and create seven new ones. If you click it again on Sunday, it'll delete yesterday's (Saturday's) bucket, create next Saturday's bucket, and leave the other six alone. Handy if you'd labeled any of them. Note that if you've manually created a bucket farther for next Sunday or later, or a second bucket for any day this week, they'll get be deleted.