### PR TITLE
Plan sidebar

### DIFF
--- a/src/data/useAllPlansRLO.ts
+++ b/src/data/useAllPlansRLO.ts
@@ -21,8 +21,7 @@ export default function useAllPlansRLO() {
                     } else {
                         const rlo = friendStore.getFriendRlo(ownerId);
                         if (rlo.data) {
-                            // eslint-disable-next-line @typescript-eslint/no-extra-non-null-assertion
-                            ownerName = rlo.data.name!!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+                            ownerName = rlo.data.name;
                         }
                     }
                     byId[p.id] = [ownerId, ownerName, p.name];

--- a/src/features/Planner/components/DragContainer.tsx
+++ b/src/features/Planner/components/DragContainer.tsx
@@ -9,8 +9,8 @@ import {
 import { BfsId } from "global/types/identity";
 import { Box, lighten, useTheme } from "@mui/material";
 
-type Vert = "above" | "below";
-type Horiz = "left" | "right" | "none";
+export type Vert = "above" | "below";
+export type Horiz = "left" | "right" | "none";
 
 interface Props extends DndContextProps {
     renderOverlay?(activeId: BfsId): React.ReactNode;

--- a/src/features/Planner/components/Item.js
+++ b/src/features/Planner/components/Item.js
@@ -18,9 +18,11 @@ const Item = ({
     className,
     hideDivider,
     dragId,
+    noDrag = false,
     ...props
 }) => {
-    const draggable = dragId != null;
+    const droppable = dragId != null;
+    const draggable = droppable && !noDrag;
     const {
         attributes,
         listeners,
@@ -33,7 +35,7 @@ const Item = ({
     });
     const { isOver, setNodeRef: setDroppableRef } = useDroppable({
         id: dragId,
-        disabled: !draggable,
+        disabled: !droppable,
     });
     const setNodeRef = (...args) => {
         setDraggableRef(...args);
@@ -47,11 +49,11 @@ const Item = ({
             className={classnames(className, {
                 [classes.root]: !hideDivider,
                 [classes.dragging]: draggable && isDragging,
-                [classes.over]: draggable && isOver && !isDragging,
+                [classes.over]: droppable && isOver && !isDragging,
             })}
             {...props}
         >
-            {(draggable || prefix || depth) && (
+            {(draggable || prefix || depth > 0) && (
                 <ListItemIcon>
                     {draggable && (
                         <DragHandle
@@ -89,6 +91,7 @@ Item.propTypes = {
     className: PropTypes.string,
     hideDivider: PropTypes.bool,
     dragId: PropTypes.any,
+    noDrag: PropTypes.bool,
 };
 
 export default withStyles((theme) => ({

--- a/src/features/Planner/components/PlanItemBucketChip.js
+++ b/src/features/Planner/components/PlanItemBucketChip.js
@@ -136,15 +136,17 @@ BucketChip.propTypes = {
     offPlan: PropTypes.bool,
 };
 
+export function assignItemToBucket(itemId, bucketId) {
+    dispatcher.dispatch({
+        type: PlanActions.ASSIGN_ITEM_TO_BUCKET,
+        id: itemId,
+        bucketId,
+    });
+}
+
 const PlanItemBucketChip = ({ itemId, ...props }) => (
     <BucketChip
-        onSelect={(bucketId) =>
-            dispatcher.dispatch({
-                type: PlanActions.ASSIGN_ITEM_TO_BUCKET,
-                id: itemId,
-                bucketId,
-            })
-        }
+        onSelect={(bucketId) => assignItemToBucket(itemId, bucketId)}
         onManage={() =>
             dispatcher.dispatch({
                 type: PlanActions.PLAN_DETAIL_VISIBILITY,

--- a/src/features/Planner/components/PlanItemBucketChip.js
+++ b/src/features/Planner/components/PlanItemBucketChip.js
@@ -10,7 +10,14 @@ import history from "util/history";
 import { humanDate } from "util/time";
 import ListItemIcon from "@mui/material/ListItemIcon";
 
-const BucketChip = ({ planId, bucketId, buckets = [], onSelect, onManage }) => {
+const BucketChip = ({
+    planId,
+    bucketId,
+    buckets = [],
+    onSelect,
+    onManage,
+    offPlan,
+}) => {
     const [anchorEl, setAnchorEl] = React.useState(null);
 
     const handleClick = (event) => {
@@ -67,7 +74,7 @@ const BucketChip = ({ planId, bucketId, buckets = [], onSelect, onManage }) => {
                     dense: true,
                 }}
             >
-                {bucket && (
+                {bucket && !offPlan && (
                     <MenuItem
                         onClick={() =>
                             history.push(`/plan/${planId}/bucket/${bucketId}`)
@@ -79,7 +86,7 @@ const BucketChip = ({ planId, bucketId, buckets = [], onSelect, onManage }) => {
                         Cook &quot;{getBucketLabel(bucket)}&quot;
                     </MenuItem>
                 )}
-                {bucket && <Divider />}
+                {bucket && !offPlan && <Divider />}
                 {buckets.map((b) => {
                     const selected = b === bucket;
                     return (
@@ -107,7 +114,7 @@ const BucketChip = ({ planId, bucketId, buckets = [], onSelect, onManage }) => {
                     </ListItemIcon>
                     Clear
                 </MenuItem>
-                {onManage && (
+                {onManage && !offPlan && (
                     <MenuItem onClick={handleManage}>
                         <ListItemIcon />
                         Manage Buckets
@@ -124,6 +131,7 @@ BucketChip.propTypes = {
     buckets: PropTypes.array.isRequired, // todo: PropTypes.arrayOf(bucketType).isRequired,
     onSelect: PropTypes.func.isRequired,
     onManage: PropTypes.func,
+    offPlan: PropTypes.bool,
 };
 
 const PlanItemBucketChip = ({ itemId, ...props }) => (

--- a/src/features/Planner/components/PlanItemBucketChip.js
+++ b/src/features/Planner/components/PlanItemBucketChip.js
@@ -20,6 +20,8 @@ const BucketChip = ({
 }) => {
     const [anchorEl, setAnchorEl] = React.useState(null);
 
+    if (buckets.length === 0) return null;
+
     const handleClick = (event) => {
         setAnchorEl(event.currentTarget);
     };

--- a/src/features/Planner/components/PlanSidebar.tsx
+++ b/src/features/Planner/components/PlanSidebar.tsx
@@ -21,14 +21,15 @@ import LoadingIndicator from "views/common/LoadingIndicator";
 import PlanBucketManager from "features/Planner/components/PlanBucketManager";
 import SidebarUnit from "features/Planner/components/SidebarUnit";
 import User from "views/user/User";
-import { PlanItem } from "features/Planner/data/planStore";
+import { Plan } from "features/Planner/data/planStore";
 import { UserType } from "../../../global/types/identity";
+import { mapBy } from "../../../util/groupBy";
 
 const LEVEL_NO_ACCESS = "NO_ACCESS";
 
 interface Props {
     open: boolean;
-    plan: PlanItem;
+    plan: Plan;
     onClose(): void;
 }
 
@@ -89,15 +90,7 @@ const PlanSidebar: React.FC<Props> = ({ open, onClose, plan }) => {
         return [
             loading,
             loading ? [] : friendList,
-            loading
-                ? {}
-                : friendList.reduce(
-                      (idx, f) => ({
-                          ...idx,
-                          [f.id]: f,
-                      }),
-                      {},
-                  ),
+            loading ? new Map() : mapBy(friendList, (f) => f.id),
         ];
     }, [FriendStore]);
 
@@ -135,9 +128,11 @@ const PlanSidebar: React.FC<Props> = ({ open, onClose, plan }) => {
         });
     };
 
-    const grants = plan.acl.grants || {};
-    const isMine = plan.acl.ownerId === me.id;
-    const owner = isMine ? me : friendsById[plan.acl.ownerId];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const acl = plan.acl!;
+    const grants = acl.grants || {};
+    const isMine = acl.ownerId === me.id;
+    const owner = isMine ? me : friendsById.get(acl.ownerId);
     const isAdministrator =
         isMine || includesLevel(grants[me.id], AccessLevel.ADMINISTER);
 
@@ -187,9 +182,7 @@ const PlanSidebar: React.FC<Props> = ({ open, onClose, plan }) => {
                                 {(isMine
                                     ? friendList
                                     : friendList
-                                          .filter(
-                                              (f) => f.id !== plan.acl.ownerId,
-                                          )
+                                          .filter((f) => f.id !== acl.ownerId)
                                           .concat(me)
                                 ).map((f) => (
                                     <ListItem key={f.id}>

--- a/src/features/Planner/data/PlanApi.ts
+++ b/src/features/Planner/data/PlanApi.ts
@@ -29,6 +29,7 @@ import {
 import { ensureInt } from "global/utils";
 import { BfsId } from "../../../global/types/identity";
 import { WireBucket } from "./planStore";
+import serializeObjectOfPromiseFns from "../../../util/serializeObjectOfPromiseFns";
 
 const axios = BaseAxios.create({
     baseURL: `${API_BASE_URL}/api/plan`,
@@ -117,23 +118,19 @@ const PlanApi = {
                   },
         ),
 
-    mutateTree(planId, body) {
-        axios.post(`/${planId}/mutate-tree`, body);
-    },
+    mutateTree: (planId, body) => axios.post(`/${planId}/mutate-tree`, body),
 
-    assignBucket(planId, id, bucketId) {
+    assignBucket: (planId, id, bucketId) =>
         axios.post(`/${planId}/assign-bucket`, {
             id,
             bucketId,
-        });
-    },
+        }),
 
-    reorderSubitems(id, subitemIds) {
+    reorderSubitems: (id, subitemIds) =>
         axios.post(`/${id}/reorder-subitems`, {
             id,
             subitemIds,
-        });
-    },
+        }),
 
     getDescendantsAsList: (id) =>
         promiseFlux(axios.get(`/${id}/descendants`), (r) => ({
@@ -240,4 +237,4 @@ const PlanApi = {
         ),
 };
 
-export default PlanApi;
+export default serializeObjectOfPromiseFns(PlanApi);

--- a/src/features/Planner/data/planStore.d.ts
+++ b/src/features/Planner/data/planStore.d.ts
@@ -5,6 +5,7 @@ import AccessLevel from "../../../data/AccessLevel";
 import { FluxAction } from "global/types/types";
 import { BfsId } from "global/types/identity";
 import { RippedLO } from "../../../util/ripLoadObject";
+import PlanItemStatus from "./PlanItemStatus";
 
 export interface PlanBucket {
     id: BfsId;
@@ -18,7 +19,7 @@ export interface WireBucket {
     date: Maybe<string>;
 }
 
-export interface PlanItem {
+export interface BasePlanItem {
     //  core
     id: BfsId;
     name: string;
@@ -29,21 +30,25 @@ export interface PlanItem {
     aggregateId?: number;
     componentIds?: number[];
     bucketId?: number;
-    // lists
-    acl: {
-        ownerId: number;
-        grants: Record<string, AccessLevel>;
-    };
-    buckets: PlanBucket[];
-    // item
+    // client-side
+    _expanded?: boolean;
+    _next_status?: PlanItemStatus;
+}
+
+export interface PlanItem extends BasePlanItem {
     quantity?: number;
     uomId?: number;
     units?: string;
     ingredientId?: number;
     preparation?: string;
-    // client-side
-    _expanded?: boolean;
-    _next_status?: string;
+}
+
+export interface Plan extends BasePlanItem {
+    acl: {
+        ownerId: number;
+        grants: Record<string, AccessLevel>;
+    };
+    buckets: PlanBucket[];
 }
 
 interface State {
@@ -61,14 +66,14 @@ declare class PlanStore extends FluxReduceStore<State, FluxAction> {
     getPlanIdsLO(): LoadObject<clientOrDatabaseIdType>;
     getPlanIdsRlo(): RippedLO<clientOrDatabaseIdType>;
 
-    getPlansRlo(): RippedLO<PlanItem[]>;
+    getPlansRlo(): RippedLO<Plan[]>;
 
     getChildItemRlos(id: clientOrDatabaseIdType): RippedLO<PlanItem>[];
 
     getNonDescendantComponents(id: number): PlanItem[];
 
-    getActivePlanLO(): LoadObject<PlanItem>;
-    getActivePlanRlo(): RippedLO<PlanItem>;
+    getActivePlanLO(): LoadObject<Plan>;
+    getActivePlanRlo(): RippedLO<Plan>;
 
     getActiveItem(): PlanItem;
 

--- a/src/features/Planner/data/utils.ts
+++ b/src/features/Planner/data/utils.ts
@@ -793,10 +793,12 @@ export const expandAll = forceExpansionBuilder(true);
 export const collapseAll = forceExpansionBuilder(false);
 
 export const taskLoaded = (state, task) => {
-    if (task.buckets) {
+    if (task.acl) {
         task = {
             ...task,
-            buckets: task.buckets.map(deserializeBucket).sort(bucketComparator),
+            buckets: task.buckets
+                ? task.buckets.map(deserializeBucket).sort(bucketComparator)
+                : [],
         };
     }
     let lo = state.byId[task.id] || LoadObject.empty();

--- a/src/features/RecipeDisplay/utils/recipeRloByPlanAndBucket.ts
+++ b/src/features/RecipeDisplay/utils/recipeRloByPlanAndBucket.ts
@@ -1,5 +1,5 @@
 import type { RecipeFromPlanItem } from "global/types/types";
-import planStore from "features/Planner/data/planStore";
+import planStore, { Plan } from "features/Planner/data/planStore";
 import { recipeRloFromItemRlo as buildSingleItemRecipeLO } from "features/RecipeDisplay/utils/recipeRloFromItemRlo";
 import getBucketLabel from "features/Planner/components/getBucketLabel";
 import { mapData, RippedLO } from "../../../util/ripLoadObject";
@@ -9,7 +9,7 @@ export const recipeRloByPlanAndBucket = (
     bucketId: number,
 ): RippedLO<RecipeFromPlanItem> => {
     const planRLO = planStore.getItemRlo(planId);
-    const plan = planRLO.data;
+    const plan = planRLO.data as Plan | undefined;
     if (!plan) {
         // no value means value's type is irrelevant
         return planRLO as RippedLO<any>;

--- a/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
+++ b/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
@@ -12,7 +12,11 @@ import {
 } from "@mui/material";
 import { Subheader } from "../../Navigation/components/Navigation.elements";
 import useFluxStore from "../../../data/useFluxStore";
-import planStore, { PlanBucket, PlanItem } from "../../Planner/data/planStore";
+import planStore, {
+    Plan,
+    PlanBucket,
+    PlanItem,
+} from "../../Planner/data/planStore";
 import LibraryStore from "../data/LibraryStore";
 import { Recipe } from "../../../global/types/types";
 import Divider from "@mui/material/Divider";
@@ -56,7 +60,7 @@ interface RecipeInfo extends PlanItem {
     photo: Recipe["photo"];
 }
 
-type PlanInfo = Pick<PlanItem, "id" | "name" | "buckets"> & {
+type PlanInfo = Pick<Plan, "id" | "name" | "buckets"> & {
     recipes: RecipeInfo[];
 };
 
@@ -94,6 +98,7 @@ const BodyContainer: React.FC<Props> = () => {
             recipes,
         };
     }, [planStore, LibraryStore]);
+
     if (!plan) return null;
 
     return (
@@ -101,7 +106,7 @@ const BodyContainer: React.FC<Props> = () => {
             <Subheader>{plan.name}</Subheader>
             <Divider component="li" />
             {plan.recipes.map((item) => {
-                return <Item key={item.id} item={item} plan={plan} />;
+                return <PlannedRecipe key={item.id} item={item} plan={plan} />;
             })}
         </List>
     );
@@ -112,7 +117,7 @@ interface ItemProps {
     plan: PlanInfo;
 }
 
-const Item: React.FC<ItemProps> = ({ item, plan }) => (
+const PlannedRecipe: React.FC<ItemProps> = ({ item, plan }) => (
     <ListItem key={item.id} alignItems={"flex-start"}>
         <ListItemText
             disableTypography

--- a/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
+++ b/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
@@ -1,75 +1,78 @@
 import { FlexBox } from "../../../global/components/FlexBox";
-import React, { PropsWithChildren } from "react";
+import React, { PropsWithChildren, useState } from "react";
 import { CSSObject, styled } from "@mui/material/styles";
 import {
     Drawer,
-    Grid,
-    IconButton,
     List,
-    ListItem,
     ListItemText,
+    ListSubheader,
     Typography,
 } from "@mui/material";
-import { Subheader } from "../../Navigation/components/Navigation.elements";
 import useFluxStore from "../../../data/useFluxStore";
-import planStore, {
-    Plan,
-    PlanBucket,
-    PlanItem,
-} from "../../Planner/data/planStore";
+import planStore, { PlanBucket, PlanItem } from "../../Planner/data/planStore";
 import LibraryStore from "../data/LibraryStore";
 import { Recipe } from "../../../global/types/types";
-import Divider from "@mui/material/Divider";
-import PlanItemBucketChip from "../../Planner/components/PlanItemBucketChip";
 import { mapBy } from "../../../util/groupBy";
-import PlanItemStatus, {
-    getColorForStatus,
-} from "../../Planner/data/PlanItemStatus";
+import PlanItemStatus from "../../Planner/data/PlanItemStatus";
 import DontChangeStatusButton from "../../Planner/components/DontChangeStatusButton";
-import { DeleteIcon } from "../../../views/common/icons";
-import Dispatcher from "../../../data/dispatcher";
-import PlanActions from "../../Planner/data/PlanActions";
 import { Maybe } from "graphql/jsutils/Maybe";
+import { bucketComparator } from "../../../util/comparators";
+import DragContainer from "../../Planner/components/DragContainer";
+import Item from "../../Planner/components/Item";
+import getBucketLabel from "../../Planner/components/getBucketLabel";
+import StatusIconButton from "../../Planner/components/StatusIconButton";
+import { assignItemToBucket } from "../../Planner/components/PlanItemBucketChip";
+import withStyles from "@mui/styles/withStyles";
+import { moveSubtree } from "../../Planner/components/Plan";
 
 type Props = PropsWithChildren<unknown>;
 
-export const drawerWidth = 150;
+export const drawerWidth = 200;
+const BUCKET_PREFIX = "bucket-";
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 const openedMixin: CSSObject = {
     width: drawerWidth,
     overflowX: "hidden",
 };
 
-const Sidebar = styled(Drawer)(
-    ({ theme }): CSSObject => ({
-        width: drawerWidth,
-        flexShrink: 0,
-        whiteSpace: "nowrap",
-        boxSizing: "border-box",
-        ...openedMixin,
-        "& .MuiDrawer-paper": openedMixin,
-        "& li": {
-            padding: `0 ${theme.spacing(1)}`,
+const Sidebar = styled(Drawer)({
+    width: drawerWidth,
+    flexShrink: 0,
+    whiteSpace: "nowrap",
+    boxSizing: "border-box",
+    ...openedMixin,
+    "& .MuiDrawer-paper": openedMixin,
+});
+
+const Header = styled(ListSubheader)(({ theme }) => ({
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    fontSize: theme.typography.h5.fontSize,
+    paddingLeft: theme.spacing(1),
+}));
+
+const DndItem = withStyles(() => ({
+    root: {
+        borderBottomWidth: 0,
+        "& .MuiListItemIcon-root": {
+            minWidth: 0,
         },
-    }),
-);
+    },
+}))(Item);
 
 interface RecipeInfo extends PlanItem {
     depth: number;
-    bucket: Maybe<PlanBucket>;
+    bucket?: Maybe<PlanBucket>;
     photo: Recipe["photo"];
 }
-
-type PlanInfo = Pick<Plan, "id" | "name" | "buckets"> & {
-    recipes: RecipeInfo[];
-};
 
 const BodyContainer: React.FC<Props> = () => {
     const plan = useFluxStore(() => {
         const { data: plan, loading } = planStore.getActivePlanRlo();
         if (!plan || loading) return null;
         const recipes: RecipeInfo[] = [];
-        const bucketsById = mapBy(plan.buckets, (b) => b.id);
         const dfs = (it: PlanItem, depth: number) => {
             if (it.ingredientId) {
                 const ing = LibraryStore.getIngredientRloById(it.ingredientId)
@@ -78,9 +81,6 @@ const BodyContainer: React.FC<Props> = () => {
                     recipes.push({
                         ...it,
                         depth,
-                        bucket: it.bucketId
-                            ? bucketsById.get(it.bucketId)
-                            : undefined,
                         photo: ing.photo,
                     });
                 }
@@ -90,6 +90,24 @@ const BodyContainer: React.FC<Props> = () => {
             }
         };
         dfs(plan, 0);
+
+        if (plan.buckets) {
+            const bucketsById = mapBy(plan.buckets, (b) => b.id);
+            recipes.forEach(
+                (it) =>
+                    (it.bucket = it.bucketId
+                        ? bucketsById.get(it.bucketId)
+                        : undefined),
+            );
+            recipes.sort((a, b) => {
+                const ab = a.bucket;
+                const bb = b.bucket;
+                if (ab === bb) return 0;
+                if (ab == null) return +1;
+                if (bb == null) return -1;
+                return bucketComparator(ab, bb);
+            });
+        }
 
         return {
             id: plan.id,
@@ -101,84 +119,147 @@ const BodyContainer: React.FC<Props> = () => {
 
     if (!plan) return null;
 
+    const renderItem = (item: RecipeInfo) => {
+        return <PlannedRecipe key={item.id} item={item} />;
+    };
+
+    let prevBucket: Maybe<PlanBucket>;
     return (
-        <List dense>
-            <Subheader>{plan.name}</Subheader>
-            <Divider component="li" />
-            {plan.recipes.map((item) => {
-                return <PlannedRecipe key={item.id} item={item} plan={plan} />;
-            })}
-        </List>
+        <DragContainer
+            renderOverlay={(id) => {
+                const it = plan.recipes.find((it) => it.id === id);
+                return it && renderItem(it);
+            }}
+            onDrop={(activeId, targetId, vertical) => {
+                const act = plan.recipes.find((r) => r.id === activeId);
+                if (!act) return;
+                let target: Maybe<RecipeInfo>;
+                let targetBucket: Maybe<PlanBucket>;
+                if (
+                    typeof targetId === "number" ||
+                    !targetId.startsWith(BUCKET_PREFIX)
+                ) {
+                    target = plan.recipes.find((r) => r.id === targetId);
+                    targetBucket = target?.bucket;
+                } else {
+                    const bucketId = targetId.substring(BUCKET_PREFIX.length);
+                    // triple equals won't equate 123 and "123", but BfsId allows either
+                    // eslint-disable-next-line eqeqeq
+                    targetBucket = plan?.buckets.find((b) => b.id == bucketId);
+                }
+                const doMove = target
+                    ? moveSubtree.bind(null, activeId, target, "none", vertical)
+                    : // eslint-disable-next-line @typescript-eslint/no-empty-function
+                      noop;
+                // triple equals doesn't equate null and undefined, but Maybe allows either
+                // eslint-disable-next-line eqeqeq
+                if (act.bucket != targetBucket) {
+                    assignItemToBucket(act.id, targetBucket?.id);
+                    setTimeout(doMove, 1000); // todo: ghetto! PlanApi is supposed to single-thread, but it doesn't?!
+                } else {
+                    doMove();
+                }
+            }}
+        >
+            <List dense>
+                <Header>{plan.name}</Header>
+                {plan.recipes.map((item) => {
+                    const ri = renderItem(item);
+                    if (item.bucket === prevBucket) return ri;
+                    const toDraw: PlanBucket[] = [];
+                    let hot = prevBucket == null;
+                    for (const b of plan.buckets) {
+                        if (hot) toDraw.push(b);
+                        if (b === item.bucket) break;
+                        if (b === prevBucket) hot = true;
+                    }
+                    prevBucket = item.bucket;
+                    return (
+                        <React.Fragment key={item.id}>
+                            {toDraw.map((b) => (
+                                <Bucket key={b.id} bucket={b}></Bucket>
+                            ))}
+                            {!item.bucket && <Bucket />}
+                            {ri}
+                        </React.Fragment>
+                    );
+                })}
+                {prevBucket && <Bucket />}
+            </List>
+        </DragContainer>
     );
 };
 
-interface ItemProps {
+const Subheader = withStyles((theme) => ({
+    root: {
+        paddingLeft: theme.spacing(1),
+        color: theme.palette.text.secondary,
+        borderTop: `1px solid ${theme.palette.divider}`,
+    },
+}))(DndItem);
+
+const Bucket = ({ bucket }: { bucket?: PlanBucket }) => {
+    return (
+        <Subheader dragId={BUCKET_PREFIX + (bucket ? bucket.id : -1)} noDrag>
+            <ListItemText
+                primary={
+                    bucket ? getBucketLabel(bucket) : "Ain't Got No Bucket"
+                }
+            />
+        </Subheader>
+    );
+};
+
+interface PlannedRecipeProps {
     item: RecipeInfo;
-    plan: PlanInfo;
 }
 
-const PlannedRecipe: React.FC<ItemProps> = ({ item, plan }) => (
-    <ListItem key={item.id} alignItems={"flex-start"}>
-        <ListItemText
-            disableTypography
-            primary={
+const PlannedRecipe: React.FC<PlannedRecipeProps> = ({ item }) => {
+    const [showing, setShowing] = useState(false);
+    const goingAway =
+        item._next_status === PlanItemStatus.COMPLETED ||
+        item._next_status === PlanItemStatus.DELETED;
+    return (
+        <DndItem key={item.id} dragId={item.id} position={"relative"}>
+            <ListItemText
+                onMouseEnter={() => setShowing(true)}
+                onMouseLeave={() => setShowing(false)}
+                disableTypography
+            >
                 <Typography
-                    component={"div"}
+                    component={goingAway ? "del" : "div"}
                     variant={"body2"}
                     fontWeight={"bold"}
                 >
                     {item.name}
+                    <span
+                        style={{
+                            position: "absolute",
+                            right: 0,
+                            top: 0,
+                            display: showing || goingAway ? "block" : "none",
+                        }}
+                    >
+                        {goingAway ? (
+                            <DontChangeStatusButton
+                                id={item.id}
+                                next={
+                                    item._next_status! /* eslint-disable-line @typescript-eslint/no-non-null-assertion */
+                                }
+                            />
+                        ) : (
+                            <StatusIconButton
+                                key="delete"
+                                id={item.id}
+                                next={PlanItemStatus.DELETED}
+                            />
+                        )}
+                    </span>
                 </Typography>
-            }
-            secondary={
-                <Grid
-                    container
-                    justifyContent={"space-between"}
-                    alignItems={"center"}
-                >
-                    <PlanItemBucketChip
-                        planId={plan.id}
-                        itemId={item.id}
-                        bucketId={item.bucketId}
-                        buckets={plan.buckets}
-                        offPlan={true}
-                    />
-                    {item._next_status === PlanItemStatus.COMPLETED ||
-                    item._next_status === PlanItemStatus.DELETED ? (
-                        <DontChangeStatusButton
-                            id={item.id}
-                            next={item._next_status}
-                        />
-                    ) : (
-                        <IconButton
-                            size={"small"}
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                Dispatcher.dispatch({
-                                    type: PlanActions.SET_STATUS,
-                                    id: item.id,
-                                    status: PlanItemStatus.DELETED,
-                                });
-                            }}
-                            color={"secondary"}
-                            sx={{
-                                p: 0,
-                                "&:hover": {
-                                    // this duplicates logic in coloredIconButton
-                                    color: getColorForStatus(
-                                        PlanItemStatus.DELETED,
-                                    )[500],
-                                },
-                            }}
-                        >
-                            <DeleteIcon />
-                        </IconButton>
-                    )}
-                </Grid>
-            }
-        />
-    </ListItem>
-);
+            </ListItemText>
+        </DndItem>
+    );
+};
 
 export const CurrentPlanSidebar: React.FC<Props> = ({ children }: Props) => {
     return (

--- a/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
+++ b/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
@@ -1,15 +1,29 @@
 import { FlexBox } from "../../../global/components/FlexBox";
 import React, { PropsWithChildren } from "react";
 import { CSSObject, styled } from "@mui/material/styles";
-import { Drawer, List, ListItem, ListItemText } from "@mui/material";
+import {
+    Drawer,
+    Grid,
+    IconButton,
+    List,
+    ListItem,
+    ListItemText,
+} from "@mui/material";
 import { Subheader } from "../../Navigation/components/Navigation.elements";
 import useFluxStore from "../../../data/useFluxStore";
 import planStore, { PlanItem } from "../../Planner/data/planStore";
-import { mapBy } from "../../../util/groupBy";
 import LibraryStore from "../data/LibraryStore";
 import { Recipe } from "../../../global/types/types";
-import getBucketLabel from "../../Planner/components/getBucketLabel";
 import Divider from "@mui/material/Divider";
+import PlanItemBucketChip from "../../Planner/components/PlanItemBucketChip";
+import { mapBy } from "../../../util/groupBy";
+import PlanItemStatus, {
+    getColorForStatus,
+} from "../../Planner/data/PlanItemStatus";
+import DontChangeStatusButton from "../../Planner/components/DontChangeStatusButton";
+import { DeleteIcon } from "../../../views/common/icons";
+import Dispatcher from "../../../data/dispatcher";
+import PlanActions from "../../Planner/data/PlanActions";
 
 type Props = PropsWithChildren<unknown>;
 
@@ -35,7 +49,7 @@ const Sidebar = styled(Drawer)(
 );
 
 const BodyContainer: React.FC<Props> = () => {
-    const summary = useFluxStore(() => {
+    const plan = useFluxStore(() => {
         const { data: plan, loading } = planStore.getActivePlanRlo();
         if (!plan || loading) return null;
         const recipes: any[] = [];
@@ -45,15 +59,13 @@ const BodyContainer: React.FC<Props> = () => {
                 const ing = LibraryStore.getIngredientRloById(it.ingredientId)
                     .data as Recipe;
                 if (ing && ing.type === "Recipe") {
-                    const bucket = it.bucketId
-                        ? bucketsById.get(it.bucketId)
-                        : undefined;
                     recipes.push({
-                        id: it.id,
-                        name: it.name,
+                        ...it,
                         depth,
                         bucketId: it.bucketId,
-                        bucket: bucket && getBucketLabel(bucket),
+                        bucket: it.bucketId
+                            ? bucketsById.get(it.bucketId)
+                            : undefined,
                         photo: ing.photo,
                     });
                 }
@@ -65,21 +77,78 @@ const BodyContainer: React.FC<Props> = () => {
         dfs(plan, 0);
 
         return {
+            id: plan.id,
             name: plan.name,
+            buckets: plan.buckets,
             recipes,
         };
     }, [planStore, LibraryStore]);
-    if (!summary) return null;
+    if (!plan) return null;
 
     return (
-        <List>
-            <Subheader>{summary.name}</Subheader>
+        <List dense>
+            <Subheader>{plan.name}</Subheader>
             <Divider component="li" />
-            {summary.recipes.map((r) => (
-                <ListItem key={r.id} alignItems={"flex-start"}>
-                    <ListItemText primary={r.name} secondary={r.bucket} />
-                </ListItem>
-            ))}
+            {plan.recipes.map((item) => {
+                const completing =
+                    item._next_status === PlanItemStatus.COMPLETED;
+                const deleting = item._next_status === PlanItemStatus.DELETED;
+                return (
+                    <ListItem key={item.id} alignItems={"flex-start"}>
+                        <ListItemText
+                            primary={item.name}
+                            primaryTypographyProps={{
+                                fontWeight: "bold",
+                            }}
+                            secondary={
+                                <Grid
+                                    container
+                                    justifyContent={"space-between"}
+                                    alignItems={"center"}
+                                >
+                                    <PlanItemBucketChip
+                                        planId={plan.id}
+                                        itemId={item.id}
+                                        bucketId={item.bucketId}
+                                        buckets={plan.buckets}
+                                        offPlan={true}
+                                    />
+                                    {completing || deleting ? (
+                                        <DontChangeStatusButton
+                                            id={item.id}
+                                            next={item._next_status}
+                                        />
+                                    ) : (
+                                        <IconButton
+                                            size={"small"}
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                Dispatcher.dispatch({
+                                                    type: PlanActions.SET_STATUS,
+                                                    id: item.id,
+                                                    status: PlanItemStatus.DELETED,
+                                                });
+                                            }}
+                                            color={"secondary"}
+                                            sx={{
+                                                p: 0,
+                                                "&:hover": {
+                                                    // this duplicates logic in coloredIconButton
+                                                    color: getColorForStatus(
+                                                        PlanItemStatus.DELETED,
+                                                    )[500],
+                                                },
+                                            }}
+                                        >
+                                            <DeleteIcon />
+                                        </IconButton>
+                                    )}
+                                </Grid>
+                            }
+                        />
+                    </ListItem>
+                );
+            })}
         </List>
     );
 };

--- a/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
+++ b/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
@@ -1,0 +1,96 @@
+import { FlexBox } from "../../../global/components/FlexBox";
+import React, { PropsWithChildren } from "react";
+import { CSSObject, styled } from "@mui/material/styles";
+import { Drawer, List, ListItem, ListItemText } from "@mui/material";
+import { Subheader } from "../../Navigation/components/Navigation.elements";
+import useFluxStore from "../../../data/useFluxStore";
+import planStore, { PlanItem } from "../../Planner/data/planStore";
+import { mapBy } from "../../../util/groupBy";
+import LibraryStore from "../data/LibraryStore";
+import { Recipe } from "../../../global/types/types";
+import getBucketLabel from "../../Planner/components/getBucketLabel";
+import Divider from "@mui/material/Divider";
+
+type Props = PropsWithChildren<unknown>;
+
+export const drawerWidth = 150;
+
+const openedMixin: CSSObject = {
+    width: drawerWidth,
+    overflowX: "hidden",
+};
+
+const Sidebar = styled(Drawer)(
+    ({ theme }): CSSObject => ({
+        width: drawerWidth,
+        flexShrink: 0,
+        whiteSpace: "nowrap",
+        boxSizing: "border-box",
+        ...openedMixin,
+        "& .MuiDrawer-paper": openedMixin,
+        "& li": {
+            padding: `0 ${theme.spacing(1)}`,
+        },
+    }),
+);
+
+const BodyContainer: React.FC<Props> = () => {
+    const summary = useFluxStore(() => {
+        const { data: plan, loading } = planStore.getActivePlanRlo();
+        if (!plan || loading) return null;
+        const recipes: any[] = [];
+        const bucketsById = mapBy(plan.buckets, (b) => b.id);
+        const dfs = (it: PlanItem, depth: number) => {
+            if (it.ingredientId) {
+                const ing = LibraryStore.getIngredientRloById(it.ingredientId)
+                    .data as Recipe;
+                if (ing && ing.type === "Recipe") {
+                    const bucket = it.bucketId
+                        ? bucketsById.get(it.bucketId)
+                        : undefined;
+                    recipes.push({
+                        id: it.id,
+                        name: it.name,
+                        depth,
+                        bucketId: it.bucketId,
+                        bucket: bucket && getBucketLabel(bucket),
+                        photo: ing.photo,
+                    });
+                }
+            }
+            for (const kid of planStore.getChildItemRlos(it.id)) {
+                if (!kid.loading && kid.data) dfs(kid.data, depth + 1);
+            }
+        };
+        dfs(plan, 0);
+
+        return {
+            name: plan.name,
+            recipes,
+        };
+    }, [planStore, LibraryStore]);
+    if (!summary) return null;
+
+    return (
+        <List>
+            <Subheader>{summary.name}</Subheader>
+            <Divider component="li" />
+            {summary.recipes.map((r) => (
+                <ListItem key={r.id} alignItems={"flex-start"}>
+                    <ListItemText primary={r.name} secondary={r.bucket} />
+                </ListItem>
+            ))}
+        </List>
+    );
+};
+
+export const CurrentPlanSidebar: React.FC<Props> = ({ children }: Props) => {
+    return (
+        <FlexBox>
+            <div>{children}</div>
+            <Sidebar variant="permanent" anchor={"right"}>
+                <BodyContainer />
+            </Sidebar>
+        </FlexBox>
+    );
+};

--- a/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
+++ b/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
@@ -163,15 +163,21 @@ const BodyContainer: React.FC<Props> = () => {
         >
             <List dense>
                 <Header>{plan.name}</Header>
-                {plan.recipes.map((item) => {
+                {plan.recipes.map((item, i) => {
                     const ri = renderItem(item);
-                    if (item.bucket === prevBucket) return ri;
                     const toDraw: PlanBucket[] = [];
-                    let hot = prevBucket == null;
-                    for (const b of plan.buckets) {
-                        if (hot) toDraw.push(b);
-                        if (b === item.bucket) break;
-                        if (b === prevBucket) hot = true;
+                    if (i === 0 && !item.bucket) {
+                        // no recipes are assigned to a bucket
+                        toDraw.push(...plan.buckets);
+                    } else if (item.bucket === prevBucket) {
+                        return ri;
+                    } else {
+                        let hot = prevBucket == null;
+                        for (const b of plan.buckets) {
+                            if (hot) toDraw.push(b);
+                            if (b === item.bucket) break;
+                            if (b === prevBucket) hot = true;
+                        }
                     }
                     prevBucket = item.bucket;
                     return (
@@ -179,7 +185,9 @@ const BodyContainer: React.FC<Props> = () => {
                             {toDraw.map((b) => (
                                 <Bucket key={b.id} bucket={b}></Bucket>
                             ))}
-                            {!item.bucket && <Bucket />}
+                            {!item.bucket && plan.buckets.length > 0 && (
+                                <Bucket />
+                            )}
                             {ri}
                         </React.Fragment>
                     );

--- a/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
+++ b/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
@@ -29,8 +29,6 @@ type Props = PropsWithChildren<unknown>;
 
 export const drawerWidth = 200;
 const BUCKET_PREFIX = "bucket-";
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
 
 const openedMixin: CSSObject = {
     width: drawerWidth,
@@ -147,17 +145,13 @@ const BodyContainer: React.FC<Props> = () => {
                     // eslint-disable-next-line eqeqeq
                     targetBucket = plan?.buckets.find((b) => b.id == bucketId);
                 }
-                const doMove = target
-                    ? moveSubtree.bind(null, activeId, target, "none", vertical)
-                    : // eslint-disable-next-line @typescript-eslint/no-empty-function
-                      noop;
                 // triple equals doesn't equate null and undefined, but Maybe allows either
                 // eslint-disable-next-line eqeqeq
                 if (act.bucket != targetBucket) {
                     assignItemToBucket(act.id, targetBucket?.id);
-                    setTimeout(doMove, 1000); // todo: ghetto! PlanApi is supposed to single-thread, but it doesn't?!
-                } else {
-                    doMove();
+                }
+                if (target) {
+                    moveSubtree(activeId, target, "none", vertical);
                 }
             }}
         >

--- a/src/features/RecipeLibrary/components/RecipesList.tsx
+++ b/src/features/RecipeLibrary/components/RecipesList.tsx
@@ -12,6 +12,8 @@ import LoadingIndicator from "views/common/LoadingIndicator";
 import { LibrarySearchScope } from "__generated__/graphql";
 import { MessagePaper } from "features/RecipeLibrary/components/MessagePaper";
 import { SearchRecipes } from "features/RecipeLibrary/components/SearchRecipes";
+import useIsDevMode from "../../../data/useIsDevMode";
+import { CurrentPlanSidebar, drawerWidth } from "./CurrentPlanSidebar";
 
 interface RecipesListProps {
     me: any; // todo
@@ -41,6 +43,7 @@ export const RecipesList: React.FC<RecipesListProps> = ({
         threshold: 15,
     });
     const isMobile = useIsMobile();
+    const isDevMode = useIsDevMode();
     const [unsavedFilter, setUnsavedFilter] = useState(filter);
 
     function handleSearchChange(e) {
@@ -127,9 +130,8 @@ export const RecipesList: React.FC<RecipesListProps> = ({
     } else {
         body = <LoadingIndicator />;
     }
-
-    return (
-        <Content disableGutters={!isMobile}>
+    body = (
+        <>
             <SearchRecipes
                 isSearchFloating={isSearchFloating}
                 isMobile={isMobile}
@@ -141,7 +143,21 @@ export const RecipesList: React.FC<RecipesListProps> = ({
                 toggleScope={toggleScope}
             />
             {body}
-            <FoodingerFab onClick={() => history.push(`/add`)}>
+        </>
+    );
+
+    let fabSx: any = undefined;
+    if (!isMobile && isDevMode) {
+        fabSx = {
+            right: (theme) => `calc(${theme.spacing(2)} + ${drawerWidth}px)`,
+        };
+        body = <CurrentPlanSidebar>{body}</CurrentPlanSidebar>;
+    }
+
+    return (
+        <Content disableGutters={!isMobile}>
+            {body}
+            <FoodingerFab onClick={() => history.push(`/add`)} sx={fabSx}>
                 <AddRecipeIcon />
             </FoodingerFab>
         </Content>

--- a/src/util/groupBy.ts
+++ b/src/util/groupBy.ts
@@ -25,4 +25,28 @@ function groupBy<K, T>(
     }, new Map());
 }
 
+/**
+ * I return a map of items, based on their extracted key. An error will be
+ * raised if any extracted key is undefined (think NullPointerException), or if
+ * two items extract the same key (think DuplicateKeyException).
+ *
+ * @param items THe items to map by key
+ * @param keyExtractor Function to extract a key from a single item
+ */
+export function mapBy<K, T>(
+    items: T[],
+    keyExtractor: (t: T) => K | undefined,
+): Map<K, T> {
+    const result = new Map<K, T>();
+    if (!items || items.length === 0) return result;
+    for (const t of items) {
+        const k = keyExtractor(t);
+        if (k == null) throw new Error("Item returned undefined key");
+        if (result.has(k))
+            throw new Error(`Item returned duplicate key '${k}'`);
+        result.set(k, t);
+    }
+    return result;
+}
+
 export default groupBy;

--- a/src/views/common/SplitButton.tsx
+++ b/src/views/common/SplitButton.tsx
@@ -96,6 +96,9 @@ const SplitButton = <TOption,>({
                         disabled={
                             dropdownDisabled || !options || !options.length
                         }
+                        sx={{
+                            paddingX: 0,
+                        }}
                     >
                         <DropDownIcon />
                     </Button>


### PR DESCRIPTION
Behind 'dev mode', add a sidebar to recipe library, giving a high-level overview of the active plan. Only recipes are shown, and can be dragged to reorder. If the plan has buckets, they are used to make sections, and recipes can be dragged between buckets, as well as reordered within a bucket.

This is proof-of-concept of two different things:

1. displaying some plan information on the library
2. treating buckets as _containers_, rather than _tags_.