### PR TITLE
Dark mode

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -70,8 +70,9 @@ body {
         }
     }
 }
+
 .MuiDataGrid-row.duplicates-of {
-    background-color: #fff9c4; // `yellow[100]` from Material
+    background-color: rgba(255, 228, 1, 0.26);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -98,4 +99,5 @@ body {
             }
         }
     }
+
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -71,6 +71,28 @@ body {
     }
 }
 
+.el-edit {
+    .quantity {
+        background-color: #fde;
+    }
+
+    .unit {
+        background-color: #efd;
+    }
+
+    .new-unit {
+        background-color: #dfe;
+    }
+
+    .ingredient {
+        background-color: #def;
+    }
+
+    .new-ingredient {
+        background-color: #edf;
+    }
+}
+
 .MuiDataGrid-row.duplicates-of {
     background-color: rgba(255, 228, 1, 0.26);
 }
@@ -100,4 +122,25 @@ body {
         }
     }
 
+    .el-edit {
+        .quantity {
+            background-color: darken(desaturate(#fde, 30), 70);
+        }
+
+        .unit {
+            background-color: darken(desaturate(#efd, 30), 80);
+        }
+
+        .new-unit {
+            background-color: darken(desaturate(#dfe, 60), 65);
+        }
+
+        .ingredient {
+            background-color: darken(desaturate(#def, 30), 75);
+        }
+
+        .new-ingredient {
+            background-color: darken(desaturate(#edf, 30), 65);
+        }
+    }
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -73,3 +73,29 @@ body {
 .MuiDataGrid-row.duplicates-of {
     background-color: #fff9c4; // `yellow[100]` from Material
 }
+
+@media (prefers-color-scheme: dark) {
+    .markdown {
+        .diff {
+            .range {
+                color: #a990d7;
+            }
+
+            .inserted {
+                background-color: #212622;
+                color: #22c953;
+            }
+
+            .deleted {
+                background-color: #1e1111;
+                color: #ef899b;
+            }
+        }
+
+        ol li {
+            &::before {
+                color: #ff9595;
+            }
+        }
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import {
     Theme,
     ThemeProvider,
 } from "@mui/material/styles";
-import theme from "./theme";
+import { useBfsTheme } from "./theme";
 import CssBaseline from "@mui/material/CssBaseline";
 import { NavigationController } from "features/Navigation/NavigationController";
 import RoutingSwitch from "RoutingSwitch";
@@ -26,7 +26,7 @@ function App() {
 
     return (
         <StyledEngineProvider injectFirst>
-            <ThemeProvider theme={theme}>
+            <ThemeProvider theme={useBfsTheme()}>
                 <CssBaseline />
                 <NavigationController authenticated={authenticated}>
                     {authenticated && newVersionAvailable && (

--- a/src/data/snackBarStore.js
+++ b/src/data/snackBarStore.js
@@ -41,7 +41,7 @@ const forPlanItemStatusChanges = (state, ids, status) => {
         renderAction(dismiss) {
             return (
                 <Button
-                    color="secondary"
+                    color="neutral"
                     size="small"
                     onClick={(e) => {
                         dismiss(e);

--- a/src/features/Navigation/NavigationController.tsx
+++ b/src/features/Navigation/NavigationController.tsx
@@ -7,7 +7,6 @@ import {
 } from "features/Navigation/components/Navigation.elements";
 import { FlexBox } from "global/components/FlexBox";
 import useFluxStore from "data/useFluxStore";
-import useIsDevMode from "data/useIsDevMode";
 import { useIsMobile } from "providers/IsMobile";
 import { MobileNav } from "features/Navigation/components/MobileNav";
 import { DesktopNav } from "features/Navigation/components/DesktopNav";
@@ -47,7 +46,6 @@ export const NavigationController: React.FC<NavigationControllerProps> = ({
 }) => {
     const expanded = !useIsNavCollapsed();
     const isMobile = useIsMobile();
-    const devMode = useIsDevMode();
     const history = useHistory();
     const [selected, setSelected] = React.useState("");
 
@@ -103,7 +101,7 @@ export const NavigationController: React.FC<NavigationControllerProps> = ({
         return (
             <MainMobile>
                 <Header elevation={0} />
-                <MobileNav selected={selected} devMode={devMode} />
+                <MobileNav selected={selected} />
                 {children}
             </MainMobile>
         );
@@ -121,7 +119,6 @@ export const NavigationController: React.FC<NavigationControllerProps> = ({
                 onSelectPlan={handleSelectPlan}
                 onOpenPlan={handleOpenPlan}
                 onExpand={handleExpand}
-                devMode={devMode}
             />
             <MainDesktop open={expanded}>{children}</MainDesktop>
         </FlexBox>

--- a/src/features/Navigation/NavigationController.tsx
+++ b/src/features/Navigation/NavigationController.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { ReactNode, useEffect } from "react";
-import CssBaseline from "@mui/material/CssBaseline";
 import {
     Header,
     MainDesktop,
@@ -112,7 +111,6 @@ export const NavigationController: React.FC<NavigationControllerProps> = ({
 
     return (
         <FlexBox>
-            <CssBaseline />
             <Header elevation={0} />
             <DesktopNav
                 selected={selected}

--- a/src/features/Navigation/components/DesktopNav.tsx
+++ b/src/features/Navigation/components/DesktopNav.tsx
@@ -23,6 +23,7 @@ import { useProfile } from "providers/Profile";
 import { NavShopItem } from "./NavShopItem";
 import { BfsId } from "global/types/identity";
 import { useGetAllPlans } from "data/hooks/useGetAllPlans";
+import useIsDevMode from "../../../data/useIsDevMode";
 
 type DesktopNavProps = {
     selected: string;
@@ -33,7 +34,6 @@ type DesktopNavProps = {
     shopView?: boolean;
     onExpand: () => void;
     expanded?: boolean;
-    devMode?: boolean;
 };
 
 export const DesktopNav: React.FC<DesktopNavProps> = ({
@@ -45,9 +45,9 @@ export const DesktopNav: React.FC<DesktopNavProps> = ({
     onOpenPlan,
     shopView,
     expanded = false,
-    devMode = false,
 }) => {
     const me = useProfile();
+    const devMode = useIsDevMode();
     const { data: planItems } = useGetAllPlans();
 
     const PlanItem = shopView ? NavShopItem : NavPlanItem;

--- a/src/features/Navigation/components/MobileNav.tsx
+++ b/src/features/Navigation/components/MobileNav.tsx
@@ -16,13 +16,9 @@ const NavWrapper = styled(Paper)(({ theme }) => ({
 
 type MobileNavProps = {
     selected?: string;
-    devMode?: boolean;
 };
 
-export const MobileNav: React.FC<MobileNavProps> = ({
-    selected = false,
-    devMode = false,
-}) => {
+export const MobileNav: React.FC<MobileNavProps> = ({ selected = false }) => {
     const me = useProfile();
     return (
         <NavWrapper elevation={3}>

--- a/src/features/Planner/components/DragContainer.tsx
+++ b/src/features/Planner/components/DragContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useLayoutEffect, useState } from "react";
 import {
     DndContext,
     DndContextProps,
@@ -7,7 +7,7 @@ import {
     rectIntersection,
 } from "@dnd-kit/core";
 import { BfsId } from "global/types/identity";
-import { Box, lighten, useTheme } from "@mui/material";
+import { Box, darken, lighten, useTheme } from "@mui/material";
 
 type Vert = "above" | "below";
 type Horiz = "left" | "right" | "none";
@@ -40,6 +40,18 @@ const DragContainer: React.FC<Props> = ({
     const [activeId, setActiveId] = useState(undefined);
     const overlay =
         renderOverlay && activeId !== undefined && renderOverlay(activeId);
+    const [overlayStyles, setOverlayStyles] = useState({});
+
+    useLayoutEffect(() => {
+        setOverlayStyles({
+            backgroundColor:
+                theme.palette.mode === "dark"
+                    ? darken(theme.palette.primary.main, 0.4)
+                    : lighten(theme.palette.primary.main, 0.4),
+            opacity: 0.85,
+            listStyle: "none",
+        });
+    }, [theme.palette.mode, theme.palette.primary.main]);
 
     function handleDragStart(event) {
         setActiveId(event.active.id);
@@ -75,20 +87,7 @@ const DragContainer: React.FC<Props> = ({
         >
             {children}
             <DragOverlay>
-                {overlay ? (
-                    <Box
-                        style={{
-                            backgroundColor: lighten(
-                                theme.palette.primary.main,
-                                0.4,
-                            ),
-                            opacity: 0.85,
-                            listStyle: "none",
-                        }}
-                    >
-                        {overlay}
-                    </Box>
-                ) : null}
+                {overlay ? <Box style={overlayStyles}>{overlay}</Box> : null}
             </DragOverlay>
         </DndContext>
     );

--- a/src/features/Planner/components/Item.js
+++ b/src/features/Planner/components/Item.js
@@ -105,8 +105,8 @@ export default withStyles((theme) => ({
     over: {
         backgroundColor:
             theme.palette.mode === "dark"
-                ? lighten(theme.palette.secondary.main, 0.2) + " !important"
-                : darken(theme.palette.secondary.main, 0.2) + " !important",
+                ? lighten(theme.palette.neutral.main, 0.2) + " !important"
+                : darken(theme.palette.neutral.main, 0.2) + " !important",
     },
     dragging: {
         opacity: 0.3,

--- a/src/features/Planner/components/Item.js
+++ b/src/features/Planner/components/Item.js
@@ -7,7 +7,7 @@ import React from "react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import DragHandle from "./DragHandle";
 import classnames from "classnames";
-import { darken } from "@mui/material";
+import { darken, lighten } from "@mui/material";
 
 const Item = ({
     depth = 0,
@@ -97,7 +97,9 @@ export default withStyles((theme) => ({
     },
     over: {
         backgroundColor:
-            darken(theme.palette.secondary.main, 0.2) + " !important",
+            theme.palette.mode === "dark"
+                ? lighten(theme.palette.secondary.main, 0.2) + " !important"
+                : darken(theme.palette.secondary.main, 0.2) + " !important",
     },
     dragging: {
         opacity: 0.3,

--- a/src/features/Planner/components/Item.js
+++ b/src/features/Planner/components/Item.js
@@ -93,7 +93,11 @@ Item.propTypes = {
 
 export default withStyles((theme) => ({
     root: {
-        borderBottom: "1px solid #eee",
+        borderBottom:
+            "1px solid " +
+            (theme.palette.mode === "dark"
+                ? theme.palette.neutral.light
+                : theme.palette.neutral.main),
     },
     over: {
         backgroundColor:

--- a/src/features/Planner/components/PlanItemBucketChip.js
+++ b/src/features/Planner/components/PlanItemBucketChip.js
@@ -62,7 +62,7 @@ const BucketChip = ({
         <>
             <Chip
                 size="small"
-                color="secondary"
+                color="neutral"
                 onClick={handleClick}
                 {...chipProps}
             />

--- a/src/features/Planner/components/PlanSidebar.tsx
+++ b/src/features/Planner/components/PlanSidebar.tsx
@@ -148,7 +148,6 @@ const PlanSidebar: React.FC<Props> = ({ open, onClose, plan }) => {
                     minHeight: "100%",
                     minWidth: "40vw",
                     maxWidth: "90vw",
-                    backgroundColor: "#f7f7f7",
                 }}
             >
                 <Box m={2}>

--- a/src/features/Planner/components/SidebarUnit.tsx
+++ b/src/features/Planner/components/SidebarUnit.tsx
@@ -4,7 +4,6 @@ import React from "react";
 
 const useStyles = makeStyles((theme) => ({
     root: {
-        backgroundColor: "white",
         marginTop: theme.spacing(2),
         marginBottom: theme.spacing(2),
         padding: theme.spacing(1),

--- a/src/features/Planner/components/withItemStyles.ts
+++ b/src/features/Planner/components/withItemStyles.ts
@@ -7,15 +7,19 @@ import {
     questionColor,
     selectionColor,
 } from "views/common/colors";
+import { darken, lighten } from "@mui/material";
 
-const withItemStyles = withStyles({
+const withItemStyles = withStyles((theme) => ({
     text: {
         whiteSpace: "nowrap",
         overflow: "hidden",
         textOverflow: "ellipsis",
     },
     section: {
-        borderBottomColor: "#ccc",
+        borderBottomColor:
+            theme.palette.mode === "dark"
+                ? lighten(theme.palette.neutral.light, 0.2)
+                : darken(theme.palette.neutral.main, 0.25),
         "& input": {
             fontWeight: "bold",
         },
@@ -51,6 +55,6 @@ const withItemStyles = withStyles({
         opacity: 0.6,
         textDecoration: "line-through",
     },
-});
+}));
 
 export default withItemStyles;

--- a/src/features/Planner/components/withItemStyles.ts
+++ b/src/features/Planner/components/withItemStyles.ts
@@ -28,28 +28,47 @@ const withItemStyles = withStyles((theme) => ({
         },
     },
     question: {
-        backgroundColor: questionColor[100],
+        backgroundColor:
+            theme.palette.mode === "dark"
+                ? darken(questionColor["A200"], 0.7)
+                : questionColor[100],
     },
     active: {
-        backgroundColor: selectionColor[100],
+        backgroundColor:
+            theme.palette.mode === "dark"
+                ? darken(selectionColor[900], 0.4)
+                : selectionColor[100],
     },
     selected: {
-        backgroundColor: selectionColor[50],
+        backgroundColor:
+            theme.palette.mode === "dark"
+                ? darken(selectionColor[900], 0.6)
+                : selectionColor[50],
     },
     acquiring: {
-        backgroundColor: acquiredColor[50],
+        backgroundColor:
+            theme.palette.mode === "dark"
+                ? darken(acquiredColor[900], 0.7)
+                : acquiredColor[50],
     },
     needing: {
-        backgroundColor: neededColor[100],
+        backgroundColor:
+            theme.palette.mode === "dark" ? neededColor[900] : neededColor[100],
     },
     deleting: {
         opacity: 0.8,
         textDecoration: "line-through",
-        backgroundColor: deleteColor[50],
+        backgroundColor:
+            theme.palette.mode === "dark"
+                ? darken(deleteColor[900], 0.4)
+                : deleteColor[50],
     },
     completing: {
         opacity: 0.8,
-        backgroundColor: completeColor[50],
+        backgroundColor:
+            theme.palette.mode === "dark"
+                ? darken(completeColor[900], 0.4)
+                : completeColor[50],
     },
     ancestorDeleting: {
         opacity: 0.6,

--- a/src/features/RecipeDisplay/components/RecipeDetail.tsx
+++ b/src/features/RecipeDisplay/components/RecipeDetail.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles((theme) => ({
         [theme.breakpoints.down("sm")]: {
             flexWrap: "wrap-reverse",
         },
-        backgroundColor: "white",
+        backgroundColor: theme.palette.background.paper,
         padding: 0,
     },
 }));

--- a/src/features/RecipeEdit/components/RecipeForm.tsx
+++ b/src/features/RecipeEdit/components/RecipeForm.tsx
@@ -166,7 +166,8 @@ const RecipeForm: React.FC<Props> = ({
                             onImage={(file) => onUpdate("photoUpload", file)}
                             style={{
                                 display: "inline-block",
-                                backgroundColor: "#eee",
+                                backgroundColor:
+                                    theme.palette.background.default,
                                 textAlign: "center",
                                 cursor: "pointer",
                             }}

--- a/src/features/RecipeEdit/components/RecipeForm.tsx
+++ b/src/features/RecipeEdit/components/RecipeForm.tsx
@@ -236,7 +236,7 @@ const RecipeForm: React.FC<Props> = ({
             <Button
                 className={classes.button}
                 startIcon={<AddIcon />}
-                color="secondary"
+                color="neutral"
                 variant="contained"
                 onClick={() => onAddIngredientRef()}
             >
@@ -319,7 +319,7 @@ const RecipeForm: React.FC<Props> = ({
                         <Button
                             className={classes.button}
                             variant="contained"
-                            color="secondary"
+                            color="neutral"
                             startIcon={<CopyIcon />}
                             onClick={() => onSaveCopy(draft)}
                         >
@@ -329,7 +329,7 @@ const RecipeForm: React.FC<Props> = ({
                     <Button
                         className={classes.button}
                         variant="contained"
-                        color="secondary"
+                        color="neutral"
                         onClick={() => onCancel(draft)}
                         startIcon={<CancelIcon />}
                     >

--- a/src/features/RecipeEdit/components/TextractButton.tsx
+++ b/src/features/RecipeEdit/components/TextractButton.tsx
@@ -3,16 +3,16 @@ import { makeStyles } from "@mui/styles";
 import { LibraryIcon, TextractIcon } from "views/common/icons";
 import React, { MouseEventHandler } from "react";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
     trigger: {
         position: "absolute",
         right: 0,
         zIndex: 1000,
-        backgroundColor: "white",
+        backgroundColor: theme.palette.background.paper,
         transformOrigin: "bottom right",
         transform: `rotate(90deg) translateY(100%) translateX(50%)`,
     },
-});
+}));
 
 interface Props {
     onClick: MouseEventHandler;

--- a/src/features/RecipeEdit/components/TextractEditor.tsx
+++ b/src/features/RecipeEdit/components/TextractEditor.tsx
@@ -1,4 +1,4 @@
-import { Box, Grid, IconButton, Typography } from "@mui/material";
+import { Box, Grid, IconButton, TextField, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import {
     CloseIcon,
@@ -329,19 +329,29 @@ const TextractEditor: React.FC<Props> = ({
                         <Typography component={"p"} variant={"h6"}>
                             Select some text on your photo.
                         </Typography>
-                        <textarea
+                        <TextField
+                            multiline
+                            variant="outlined"
+                            size={"small"}
+                            fullWidth
+                            minRows={4}
                             value={selectedText.join("\n")}
                             onChange={(e) =>
                                 setSelectedText(e.target.value.split("\n"))
                             }
-                            style={{
-                                width: "100%",
-                                height: `calc(${
-                                    rotation % 180 === 0
-                                        ? scaledHeight
-                                        : scaledWidth
-                                }px - 100px)`,
-                                whiteSpace: "pre",
+                            inputProps={{
+                                sx: {
+                                    // width: "100%",
+                                    // height: `${Math.max(
+                                    //     100,
+                                    //     (rotation % 180 === 0
+                                    //         ? scaledHeight
+                                    //         : scaledWidth) - 100,
+                                    // )}px`,
+                                    whiteSpace: "pre",
+                                    fontFamily: "monospace",
+                                    fontSize: "80%",
+                                },
                             }}
                         />
                         {renderActions && renderActions(selectedText)}

--- a/src/features/RecipeEdit/components/TextractQueueBrowser.tsx
+++ b/src/features/RecipeEdit/components/TextractQueueBrowser.tsx
@@ -1,11 +1,11 @@
 import {
+    Drawer,
     IconButton,
     ImageList,
     ImageListItem,
     ImageListItemBar,
     Typography,
 } from "@mui/material";
-import Drawer from "@mui/material/Drawer";
 import { makeStyles } from "@mui/styles";
 import { CloseIcon } from "../../../views/common/icons";
 import React, { MouseEventHandler } from "react";
@@ -16,12 +16,12 @@ import TextractApi from "data/TextractApi";
 import { PendingJob } from "features/RecipeEdit/components/TextractFormAugment";
 import { BfsId } from "global/types/identity";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
     drawer: {
         minHeight: "100%",
         minWidth: "30vw",
         maxWidth: "50vw",
-        backgroundColor: "#f7f7f7",
+        backgroundColor: theme.palette.background.paper,
         padding: "0 1em",
         position: "relative",
     },
@@ -31,7 +31,7 @@ const useStyles = makeStyles({
         width: "100%",
         textAlign: "center",
         paddingTop: "40px",
-        backgroundColor: "#eee",
+        backgroundColor: theme.palette.background.default,
         cursor: "pointer",
     },
     closeButton: {
@@ -48,7 +48,7 @@ const useStyles = makeStyles({
     deleteButton: {
         color: "white",
     },
-});
+}));
 
 interface PassthroughProps {
     onSelect: (id: string) => void;

--- a/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
+++ b/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
@@ -183,7 +183,7 @@ const BodyContainer: React.FC<Props> = () => {
 const Subheader = withStyles((theme) => ({
     root: {
         paddingLeft: theme.spacing(1),
-        color: theme.palette.text.secondary,
+        color: theme.palette.text.neutral,
         borderTop: `1px solid ${theme.palette.divider}`,
     },
 }))(DndItem);

--- a/src/features/RecipeLibrary/components/ItemImage.tsx
+++ b/src/features/RecipeLibrary/components/ItemImage.tsx
@@ -1,8 +1,7 @@
-import { CardMedia } from "@mui/material";
+import { CardMedia, useTheme } from "@mui/material";
 import React from "react";
 import { CommonProps } from "@mui/material/OverridableComponent";
 import { Maybe } from "graphql/jsutils/Maybe";
-import { grey } from "@mui/material/colors";
 
 interface Props extends CommonProps {
     url: string;
@@ -20,6 +19,7 @@ const ItemImage: React.FC<Props> = ({
 }) => {
     const x = focus ? focus[0] * 100 : 50;
     const y = focus ? focus[1] * 100 : 50;
+    const theme = useTheme();
 
     return (
         <CardMedia
@@ -28,7 +28,7 @@ const ItemImage: React.FC<Props> = ({
             {...props}
             style={{
                 ...style,
-                backgroundColor: grey[100],
+                backgroundColor: theme.palette.background.paper,
                 backgroundPosition: `${x == null ? 50 : x}% ${
                     y == null ? 50 : y
                 }%`,

--- a/src/features/RecipeLibrary/components/ItemImageUpload.tsx
+++ b/src/features/RecipeLibrary/components/ItemImageUpload.tsx
@@ -25,7 +25,6 @@ const useStyles = makeStyles({
         height: 140,
         textAlign: "center",
         paddingTop: "30px",
-        backgroundColor: "#eee",
     },
 });
 

--- a/src/features/RecipeLibrary/components/RecipesList.tsx
+++ b/src/features/RecipeLibrary/components/RecipesList.tsx
@@ -43,7 +43,7 @@ export const RecipesList: React.FC<RecipesListProps> = ({
         threshold: 15,
     });
     const isMobile = useIsMobile();
-    const isDevMode = useIsDevMode();
+    const devMode = useIsDevMode();
     const [unsavedFilter, setUnsavedFilter] = useState(filter);
 
     function handleSearchChange(e) {
@@ -147,7 +147,7 @@ export const RecipesList: React.FC<RecipesListProps> = ({
     );
 
     let fabSx: any = undefined;
-    if (!isMobile && isDevMode) {
+    if (!isMobile && devMode) {
         fabSx = {
             right: (theme) => `calc(${theme.spacing(2)} + ${drawerWidth}px)`,
         };

--- a/src/features/RecipeLibrary/components/SearchRecipes.elements.tsx
+++ b/src/features/RecipeLibrary/components/SearchRecipes.elements.tsx
@@ -3,5 +3,4 @@ import { styled } from "@mui/material/styles";
 
 export const SearchRecipesContainer = styled(AppBar)({
     marginBottom: 40,
-    backgroundColor: "white",
 });

--- a/src/features/RecipeLibrary/components/SearchRecipes.tsx
+++ b/src/features/RecipeLibrary/components/SearchRecipes.tsx
@@ -38,7 +38,7 @@ export const SearchRecipes: React.FC<SearchRecipesProps> = ({
         <SearchRecipesContainer
             elevation={isSearchFloating ? 4 : 1}
             position="sticky"
-            color="secondary"
+            color="neutral"
         >
             <Toolbar>
                 <InputBase

--- a/src/features/RecipeLibrary/components/SendToPlan.tsx
+++ b/src/features/RecipeLibrary/components/SendToPlan.tsx
@@ -55,7 +55,7 @@ const SendToPlan: React.FC<Props> = ({
                 primary={`To ${list.name}`}
                 onClick={handleClick}
                 options={scaleToPlanOpts}
-                color="secondary"
+                color="neutral"
                 variant="contained"
                 onSelect={handleSelect}
                 startIcon={<SendToPlanIcon />}
@@ -67,7 +67,7 @@ const SendToPlan: React.FC<Props> = ({
         <TextButton
             disableElevation
             variant="contained"
-            color="secondary"
+            color="neutral"
             onClick={handleClick}
             title={`Send to ${list.name}`}
             startIcon={<SendToPlanIcon />}

--- a/src/features/UserProfile/components/Developer.tsx
+++ b/src/features/UserProfile/components/Developer.tsx
@@ -165,7 +165,7 @@ const DevMode: React.FC = () => {
                 >
                     <Button
                         variant={"contained"}
-                        color={"secondary"}
+                        color={"neutral"}
                         size={"small"}
                         onClick={handleResample}
                     >

--- a/src/features/UserProfile/components/Developer.tsx
+++ b/src/features/UserProfile/components/Developer.tsx
@@ -190,7 +190,7 @@ const DevMode: React.FC = () => {
 };
 
 export const Developer: React.FC = () => {
-    const isDevMode = useIsDevMode();
+    const devMode = useIsDevMode();
 
     const handleDevModeChange = (e) => setDevMode(e.target.checked);
 
@@ -198,12 +198,12 @@ export const Developer: React.FC = () => {
         <>
             <Row label={"Dev Mode"}>
                 <Switch
-                    checked={isDevMode}
+                    checked={devMode}
                     onChange={handleDevModeChange}
                     color="primary"
                 />
             </Row>
-            {isDevMode && <DevMode />}
+            {devMode && <DevMode />}
         </>
     );
 };

--- a/src/global/components/TaskIcon.tsx
+++ b/src/global/components/TaskIcon.tsx
@@ -1,15 +1,15 @@
 import * as React from "react";
 import { ReactNode } from "react";
-import { Button, IconButton } from "@mui/material";
+import { Button } from "@mui/material";
 import { Link } from "react-router-dom";
 import { styled } from "@mui/material/styles";
 
-const ContainedIcon = styled(IconButton)(({ theme }) => ({
-    backgroundColor: theme.palette.neutral.main,
-    borderRadius: theme.shape.borderRadius,
-    color: theme.palette.neutral.contrastText,
-    "&:hover": {
-        backgroundColor: theme.palette.neutral.main,
+const ContainedIcon = styled(Button)(({ theme }) => ({
+    minWidth: "unset",
+    padding: `${theme.spacing(0.5)} ${theme.spacing(0.75)}`,
+    "& svg": {
+        width: theme.spacing(2.5),
+        height: theme.spacing(2.5),
     },
 })) as typeof Button;
 
@@ -20,7 +20,13 @@ type TaskIconProps = {
 
 export const TaskIcon: React.FC<TaskIconProps> = ({ icon, url }) => {
     return (
-        <ContainedIcon size="small" color="secondary" component={Link} to={url}>
+        <ContainedIcon
+            variant={"contained"}
+            color="neutral"
+            component={Link}
+            to={url}
+            disableElevation
+        >
             {icon}
         </ContainedIcon>
     );

--- a/src/providers/IsMobile.tsx
+++ b/src/providers/IsMobile.tsx
@@ -1,6 +1,6 @@
 import { useMediaQuery } from "@mui/material";
 import React, { createContext, PropsWithChildren, useContext } from "react";
-import theme from "../theme";
+import { useTheme } from "@mui/material/styles";
 import useFluxStore from "../data/useFluxStore";
 import preferencesStore from "../data/preferencesStore";
 
@@ -9,7 +9,7 @@ const MobileContext = createContext(true);
 type Props = PropsWithChildren<unknown>;
 
 export function IsMobileProvider({ children }: Props): React.ReactElement {
-    const bound = theme.breakpoints.values.sm;
+    const bound = useTheme().breakpoints.values.sm;
     const query = `@media (max-width:${bound}px), (max-height:${bound}px)`;
     const mobile = useMediaQuery(query, {
         noSsr: true, // don't double-render

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,9 +1,10 @@
 import {
     createTheme,
+    PaletteColorOptions,
     responsiveFontSizes,
-    Theme,
     ThemeOptions,
 } from "@mui/material/styles";
+import { deepmerge } from "@mui/utils";
 import { grey } from "@mui/material/colors";
 import { IS_BETA } from "./constants";
 import { useMediaQuery } from "@mui/material";
@@ -20,107 +21,100 @@ declare module "@mui/material/styles" {
     }
 }
 
-const typography: ThemeOptions["typography"] = {
-    fontFamily: [
-        '"Encode Sans Semi Condensed"',
-        '"Roboto"',
-        '"Arial"',
-        '"sans-serif"',
-        '"Apple Color Emoji"',
-        '"Segoe UI Emoji"',
-        '"Segoe UI Symbol"',
-    ].join(","),
-    h2: {
-        fontFamily: "'Encode Sans', sans-serif",
-        fontSize: "2.5rem",
+const baseTokens: ThemeOptions = {
+    palette: {
+        primary: {
+            light: IS_BETA ? "#90caf9" : "#F99339",
+            main: IS_BETA ? "#1976d2" : "#F57F17",
+            dark: IS_BETA ? "#0d47a1" : "#B85600",
+            contrastText: "#FFFDE7",
+        },
     },
-    h3: {
-        fontFamily: "'Encode Sans', sans-serif",
-        fontSize: "2rem",
-    },
-    h5: {
-        fontFamily: "News Cycle",
-        fontWeight: 600,
-        fontSize: "1.1rem",
-        textTransform: "uppercase",
-        marginBottom: ".5em",
+    typography: {
+        fontFamily: [
+            '"Encode Sans Semi Condensed"',
+            '"Roboto"',
+            '"Arial"',
+            '"sans-serif"',
+            '"Apple Color Emoji"',
+            '"Segoe UI Emoji"',
+            '"Segoe UI Symbol"',
+        ].join(","),
+        h2: {
+            fontFamily: "'Encode Sans', sans-serif",
+            fontSize: "2.5rem",
+        },
+        h3: {
+            fontFamily: "'Encode Sans', sans-serif",
+            fontSize: "2rem",
+        },
+        h5: {
+            fontFamily: "News Cycle",
+            fontWeight: 600,
+            fontSize: "1.1rem",
+            textTransform: "uppercase",
+            marginBottom: ".5em",
+        },
     },
 };
 
-const primary = {
-    light: IS_BETA ? "#90caf9" : "#F99339",
-    main: IS_BETA ? "#1976d2" : "#F57F17",
-    dark: IS_BETA ? "#0d47a1" : "#B85600",
-    contrastText: "#FFFDE7",
+const lightTokens: ThemeOptions = {
+    palette: {
+        secondary: {
+            main: "#EEEEEE",
+            contrastText: "#000",
+        },
+        background: {
+            default: "#f7f7f7",
+        },
+        neutral: {
+            light: grey[100],
+            main: grey[200],
+            dark: grey[700],
+            contrastText: grey[900],
+        },
+    },
+    components: {
+        MuiTextField: {
+            styleOverrides: {
+                root: {
+                    backgroundColor: "white",
+                },
+            },
+        },
+    },
 };
 
-const theme_light: () => Theme = () =>
-    createTheme({
-        palette: {
-            primary,
-            secondary: {
-                main: "#EEEEEE",
-                contrastText: "#000",
-            },
-            // secondary: {
-            //     main: "#FFFDE7",
-            //     contrastText: "#000",
-            // },
-            background: {
-                default: "#f7f7f7",
-            },
-            neutral: {
-                light: grey[100],
-                main: grey[200],
-                dark: grey[700],
-                contrastText: grey[900],
-            },
+const darkTokens: ThemeOptions = {
+    palette: {
+        mode: "dark",
+        primary: {
+            contrastText: "#000",
+        } as PaletteColorOptions,
+        secondary: {
+            main: "#151515",
+            contrastText: "#ffffff",
         },
-        typography,
-        components: {
-            MuiTextField: {
-                styleOverrides: {
-                    root: {
-                        backgroundColor: "white",
-                    },
+        background: {
+            default: "#333333",
+        },
+        neutral: {
+            light: grey[900],
+            main: "#151515",
+            dark: grey[300],
+            contrastText: "#ffffff",
+        },
+    },
+    components: {
+        MuiTextField: {
+            styleOverrides: {
+                root: {
+                    backgroundColor: "black",
                 },
             },
         },
-    });
-
-const theme_dark: () => Theme = () =>
-    createTheme({
-        palette: {
-            mode: "dark",
-            primary: {
-                ...primary,
-                contrastText: "#000",
-            },
-            secondary: {
-                main: "#151515",
-                contrastText: "#ffffff",
-            },
-            background: {
-                default: "#333333",
-            },
-            neutral: {
-                light: grey[900],
-                main: "#151515",
-                dark: grey[300],
-                contrastText: "#ffffff",
-            },
-        },
-        typography,
-        components: {
-            MuiTextField: {
-                styleOverrides: {
-                    root: {
-                        backgroundColor: "black",
-                    },
-                },
-            },
-        },
-    });
+    },
+};
 
 export function useBfsTheme() {
     const devMode = useIsDevMode();
@@ -128,7 +122,12 @@ export function useBfsTheme() {
     return useMemo(
         () =>
             responsiveFontSizes(
-                devMode && preferDark ? theme_dark() : theme_light(),
+                createTheme(
+                    deepmerge(
+                        baseTokens,
+                        devMode && preferDark ? darkTokens : lightTokens,
+                    ),
+                ),
             ),
         [devMode, preferDark],
     );

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,6 +1,14 @@
-import { createTheme, responsiveFontSizes, Theme } from "@mui/material/styles";
+import {
+    createTheme,
+    responsiveFontSizes,
+    Theme,
+    ThemeOptions,
+} from "@mui/material/styles";
 import { grey } from "@mui/material/colors";
 import { IS_BETA } from "./constants";
+import { useMediaQuery } from "@mui/material";
+import useIsDevMode from "./data/useIsDevMode";
+import { useMemo } from "react";
 
 declare module "@mui/material/styles" {
     interface Palette {
@@ -12,68 +20,116 @@ declare module "@mui/material/styles" {
     }
 }
 
-let theme: Theme = createTheme({
-    palette: {
-        primary: {
-            light: IS_BETA ? "#90caf9" : "#F99339",
-            main: IS_BETA ? "#1976d2" : "#F57F17",
-            dark: IS_BETA ? "#0d47a1" : "#B85600",
-            contrastText: "#FFFDE7",
-        },
-        secondary: {
-            main: "#EEEEEE",
-            contrastText: "#000",
-        },
-        // secondary: {
-        //     main: "#FFFDE7",
-        //     contrastText: "#000",
-        // },
-        background: {
-            default: "#f7f7f7",
-        },
-        neutral: {
-            light: grey[100],
-            main: grey[200],
-            dark: grey[700],
-            contrastText: grey[900],
-        },
+const typography: ThemeOptions["typography"] = {
+    fontFamily: [
+        '"Encode Sans Semi Condensed"',
+        '"Roboto"',
+        '"Arial"',
+        '"sans-serif"',
+        '"Apple Color Emoji"',
+        '"Segoe UI Emoji"',
+        '"Segoe UI Symbol"',
+    ].join(","),
+    h2: {
+        fontFamily: "'Encode Sans', sans-serif",
+        fontSize: "2.5rem",
     },
-    typography: {
-        fontFamily: [
-            '"Encode Sans Semi Condensed"',
-            '"Roboto"',
-            '"Arial"',
-            '"sans-serif"',
-            '"Apple Color Emoji"',
-            '"Segoe UI Emoji"',
-            '"Segoe UI Symbol"',
-        ].join(","),
-        h2: {
-            fontFamily: "'Encode Sans', sans-serif",
-            fontSize: "2.5rem",
-        },
-        h3: {
-            fontFamily: "'Encode Sans', sans-serif",
-            fontSize: "2rem",
-        },
-        h5: {
-            fontFamily: "News Cycle",
-            fontWeight: 600,
-            fontSize: "1.1rem",
-            textTransform: "uppercase",
-            marginBottom: ".5em",
-        },
+    h3: {
+        fontFamily: "'Encode Sans', sans-serif",
+        fontSize: "2rem",
     },
-    components: {
-        MuiTextField: {
-            styleOverrides: {
-                root: {
-                    backgroundColor: "white",
+    h5: {
+        fontFamily: "News Cycle",
+        fontWeight: 600,
+        fontSize: "1.1rem",
+        textTransform: "uppercase",
+        marginBottom: ".5em",
+    },
+};
+
+const theme_light: () => Theme = () =>
+    createTheme({
+        palette: {
+            primary: {
+                light: IS_BETA ? "#90caf9" : "#F99339",
+                main: IS_BETA ? "#1976d2" : "#F57F17",
+                dark: IS_BETA ? "#0d47a1" : "#B85600",
+                contrastText: "#FFFDE7",
+            },
+            secondary: {
+                main: "#EEEEEE",
+                contrastText: "#000",
+            },
+            // secondary: {
+            //     main: "#FFFDE7",
+            //     contrastText: "#000",
+            // },
+            background: {
+                default: "#f7f7f7",
+            },
+            neutral: {
+                light: grey[100],
+                main: grey[200],
+                dark: grey[700],
+                contrastText: grey[900],
+            },
+        },
+        typography,
+        components: {
+            MuiTextField: {
+                styleOverrides: {
+                    root: {
+                        backgroundColor: "white",
+                    },
                 },
             },
         },
-    },
-});
-theme = responsiveFontSizes(theme);
+    });
 
-export default theme;
+const theme_dark: () => Theme = () =>
+    createTheme({
+        palette: {
+            mode: "dark",
+            primary: {
+                light: IS_BETA ? "#1d2831" : "#36200c",
+                main: IS_BETA ? "#0b3864" : "#6b3708",
+                dark: IS_BETA ? "#092f6b" : "#673101",
+                contrastText: "#070606",
+            },
+            secondary: {
+                main: "#151515",
+                contrastText: "#ffffff",
+            },
+            background: {
+                default: "#333333",
+            },
+            neutral: {
+                light: grey[700],
+                main: grey[200],
+                dark: grey[100],
+                contrastText: grey[100],
+            },
+        },
+        typography,
+        components: {
+            MuiTextField: {
+                styleOverrides: {
+                    root: {
+                        backgroundColor: "black",
+                    },
+                },
+            },
+        },
+    });
+
+export function useBfsTheme() {
+    const devMode = useIsDevMode();
+    const preferDark = useMediaQuery("(prefers-color-scheme: dark)");
+    return useMemo(
+        () =>
+            responsiveFontSizes(
+                devMode && preferDark ? theme_dark() : theme_light(),
+            ),
+        [devMode, preferDark],
+    );
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -20,6 +20,27 @@ declare module "@mui/material/styles" {
     }
 }
 
+declare module "@mui/material/Button" {
+    interface ButtonPropsColorOverrides {
+        neutral: true;
+    }
+}
+declare module "@mui/material/ButtonGroup" {
+    interface ButtonGroupPropsColorOverrides {
+        neutral: true;
+    }
+}
+declare module "@mui/material/IconButton" {
+    interface IconButtonPropsColorOverrides {
+        neutral: true;
+    }
+}
+declare module "@mui/material/AppBar" {
+    interface AppBarPropsColorOverrides {
+        neutral: true;
+    }
+}
+
 const baseTokens: ThemeOptions = {
     palette: {
         primary: {
@@ -59,27 +80,11 @@ const baseTokens: ThemeOptions = {
 
 const lightTokens: ThemeOptions = {
     palette: {
-        secondary: {
-            main: "#EEEEEE",
-            contrastText: "#000",
-        },
         background: {
             default: "#f7f7f7",
         },
         neutral: {
-            light: grey[100],
             main: grey[200],
-            dark: grey[700],
-            contrastText: grey[900],
-        },
-    },
-    components: {
-        MuiTextField: {
-            styleOverrides: {
-                root: {
-                    backgroundColor: "white",
-                },
-            },
         },
     },
 };
@@ -87,27 +92,16 @@ const lightTokens: ThemeOptions = {
 const darkTokens: ThemeOptions = {
     palette: {
         mode: "dark",
-        secondary: {
-            main: "#151515",
-            contrastText: "#ffffff",
+        text: { primary: "#afb1b3" },
+        action: {
+            active: "#afb1b3",
         },
         background: {
-            default: "#333333",
+            default: "#2b2b2b",
+            paper: "#3d3f41",
         },
         neutral: {
-            light: grey[900],
-            main: "#151515",
-            dark: grey[300],
-            contrastText: "#ffffff",
-        },
-    },
-    components: {
-        MuiTextField: {
-            styleOverrides: {
-                root: {
-                    backgroundColor: "black",
-                },
-            },
+            main: "#313335",
         },
     },
 };
@@ -115,16 +109,24 @@ const darkTokens: ThemeOptions = {
 export function useBfsTheme() {
     const devMode = useIsDevMode();
     const preferDark = useMediaQuery("(prefers-color-scheme: dark)");
-    return useMemo(
-        () =>
-            responsiveFontSizes(
-                createTheme(
-                    deepmerge(
-                        baseTokens,
-                        devMode && preferDark ? darkTokens : lightTokens,
-                    ),
-                ),
+    return useMemo(() => {
+        const theme = createTheme(
+            deepmerge(
+                baseTokens,
+                devMode && preferDark ? darkTokens : lightTokens,
             ),
-        [devMode, preferDark],
-    );
+        );
+        return responsiveFontSizes(
+            createTheme(theme, {
+                palette: {
+                    neutral: theme.palette.augmentColor({
+                        color: {
+                            main: theme.palette.neutral.main,
+                        },
+                        name: "neutral",
+                    }),
+                },
+            }),
+        );
+    }, [devMode, preferDark]);
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,6 +1,5 @@
 import {
     createTheme,
-    PaletteColorOptions,
     responsiveFontSizes,
     ThemeOptions,
 } from "@mui/material/styles";
@@ -88,9 +87,6 @@ const lightTokens: ThemeOptions = {
 const darkTokens: ThemeOptions = {
     palette: {
         mode: "dark",
-        primary: {
-            contrastText: "#000",
-        } as PaletteColorOptions,
         secondary: {
             main: "#151515",
             contrastText: "#ffffff",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -91,7 +91,7 @@ const lightTokens: ThemeOptions = {
 const darkTokens: ThemeOptions = {
     palette: {
         mode: "dark",
-        text: { primary: "#afb1b3" },
+        text: { primary: "#c2c4c5" },
         action: {
             active: "#afb1b3",
         },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -47,15 +47,17 @@ const typography: ThemeOptions["typography"] = {
     },
 };
 
+const primary = {
+    light: IS_BETA ? "#90caf9" : "#F99339",
+    main: IS_BETA ? "#1976d2" : "#F57F17",
+    dark: IS_BETA ? "#0d47a1" : "#B85600",
+    contrastText: "#FFFDE7",
+};
+
 const theme_light: () => Theme = () =>
     createTheme({
         palette: {
-            primary: {
-                light: IS_BETA ? "#90caf9" : "#F99339",
-                main: IS_BETA ? "#1976d2" : "#F57F17",
-                dark: IS_BETA ? "#0d47a1" : "#B85600",
-                contrastText: "#FFFDE7",
-            },
+            primary,
             secondary: {
                 main: "#EEEEEE",
                 contrastText: "#000",
@@ -91,10 +93,8 @@ const theme_dark: () => Theme = () =>
         palette: {
             mode: "dark",
             primary: {
-                light: IS_BETA ? "#1d2831" : "#36200c",
-                main: IS_BETA ? "#0b3864" : "#6b3708",
-                dark: IS_BETA ? "#092f6b" : "#673101",
-                contrastText: "#070606",
+                ...primary,
+                contrastText: "#000",
             },
             secondary: {
                 main: "#151515",
@@ -104,10 +104,10 @@ const theme_dark: () => Theme = () =>
                 default: "#333333",
             },
             neutral: {
-                light: grey[700],
-                main: grey[200],
-                dark: grey[100],
-                contrastText: grey[100],
+                light: grey[900],
+                main: "#151515",
+                dark: grey[300],
+                contrastText: "#ffffff",
             },
         },
         typography,

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -7,7 +7,6 @@ import { deepmerge } from "@mui/utils";
 import { grey } from "@mui/material/colors";
 import { IS_BETA } from "./constants";
 import { useMediaQuery } from "@mui/material";
-import useIsDevMode from "./data/useIsDevMode";
 import { useMemo } from "react";
 
 declare module "@mui/material/styles" {
@@ -107,14 +106,10 @@ const darkTokens: ThemeOptions = {
 };
 
 export function useBfsTheme() {
-    const devMode = useIsDevMode();
     const preferDark = useMediaQuery("(prefers-color-scheme: dark)");
     return useMemo(() => {
         const theme = createTheme(
-            deepmerge(
-                baseTokens,
-                devMode && preferDark ? darkTokens : lightTokens,
-            ),
+            deepmerge(baseTokens, preferDark ? darkTokens : lightTokens),
         );
         return responsiveFontSizes(
             createTheme(theme, {
@@ -128,5 +123,5 @@ export function useBfsTheme() {
                 },
             }),
         );
-    }, [devMode, preferDark]);
+    }, [preferDark]);
 }

--- a/src/views/ElEdit.tsx
+++ b/src/views/ElEdit.tsx
@@ -1,6 +1,6 @@
 import { Grid, InputAdornment, LinearProgress, TextField } from "@mui/material";
 import { ErrorIcon, OkIcon } from "./common/icons";
-import React, { CSSProperties, PropsWithChildren } from "react";
+import React, { PropsWithChildren } from "react";
 import ItemApi, { RecognitionResult } from "data/ItemApi";
 import debounce from "util/debounce";
 import processRecognizedItem from "util/processRecognizedItem";
@@ -284,7 +284,7 @@ class ElEdit extends React.PureComponent<ElEditProps, ElEditState> {
                     />
                 </Grid>
 
-                <Grid item sm={6} xs={12}>
+                <Grid item sm={6} xs={12} className={"el-edit"}>
                     {!recog || !raw ? (
                         doRecog(raw) ? (
                             <Hunk>
@@ -294,28 +294,22 @@ class ElEdit extends React.PureComponent<ElEditProps, ElEditState> {
                     ) : (
                         <Hunk>
                             {quantity && (
-                                <Hunk style={{ backgroundColor: "#fde" }}>
-                                    {quantity}
-                                </Hunk>
+                                <Hunk className={"quantity"}>{quantity}</Hunk>
                             )}
                             {unit && (
                                 <Hunk
-                                    style={{
-                                        backgroundColor: unitValue
-                                            ? "#efd"
-                                            : "#dfe",
-                                    }}
+                                    className={unitValue ? "unit" : "new-unit"}
                                 >
                                     {unit}
                                 </Hunk>
                             )}
                             {ingredientName && (
                                 <Hunk
-                                    style={{
-                                        backgroundColor: nameValue
-                                            ? "#def"
-                                            : "#edf",
-                                    }}
+                                    className={
+                                        nameValue
+                                            ? "ingredient"
+                                            : "new-ingredient"
+                                    }
                                 >
                                     {ingredientName}
                                 </Hunk>
@@ -335,13 +329,13 @@ class ElEdit extends React.PureComponent<ElEditProps, ElEditState> {
 }
 
 interface HunkProps extends PropsWithChildren<unknown> {
-    style?: CSSProperties;
+    className?: string;
 }
 
-const Hunk: React.FC<HunkProps> = ({ children, style }) => (
+const Hunk: React.FC<HunkProps> = ({ children, className }) => (
     <span
+        className={className}
         style={{
-            ...style,
             marginLeft: "0.4em",
             padding: "0 0.25em",
         }}

--- a/src/views/common/Banner.tsx
+++ b/src/views/common/Banner.tsx
@@ -3,7 +3,7 @@ import { HelpIcon, InfoIcon } from "views/common/icons";
 import React, { MouseEventHandler, PropsWithChildren } from "react";
 import CloseButton from "views/common/CloseButton";
 import { lightBlue } from "@mui/material/colors";
-import { Box } from "@mui/material";
+import { alpha, Box, useTheme } from "@mui/material";
 
 interface Props extends PropsWithChildren<unknown> {
     severity?: "info";
@@ -11,13 +11,20 @@ interface Props extends PropsWithChildren<unknown> {
 }
 
 const Banner: React.FC<Props> = ({ severity, children, onClose }) => {
+    const theme = useTheme();
     return (
         <Box
             display="flex"
             alignItems="center"
             style={{
                 backgroundColor:
-                    severity === "info" ? lightBlue[100] : grey[200],
+                    theme.palette.mode === "dark"
+                        ? severity === "info"
+                            ? alpha(lightBlue[800], 0.4)
+                            : grey[700]
+                        : severity === "info"
+                        ? lightBlue[100]
+                        : grey[200],
             }}
         >
             <Box m={1}>{severity === "info" ? <InfoIcon /> : <HelpIcon />}</Box>

--- a/src/views/common/PageBody.tsx
+++ b/src/views/common/PageBody.tsx
@@ -8,7 +8,7 @@ const useStyles = makeStyles((theme) => {
     return {
         root: (props: PageBodyProps) => {
             const styles: CreateCSSProperties = {
-                backgroundColor: "white",
+                backgroundColor: theme.palette.background.paper,
                 minHeight: `calc(100vh - ${HEADER_HEIGHT}px)`,
             };
             if (props.fullWidth) {


### PR DESCRIPTION
Provide automatic switching between light and dark color schemes based on the system's setting. I believe all the necessarily colors have been inverted:

1. the theme itself
2. various `withStyles`, via `theme.palette.mode`
3. a couple inline styles, via `theme.palette.mode`
4. CSS rules (in `App.scss`) via the same media query

They were not carefully chosen, however, so tweaking will probably be needed.