### PR TITLE
planner sidebar spiffs

### DIFF
--- a/src/features/Planner/components/PlanBucketManager.tsx
+++ b/src/features/Planner/components/PlanBucketManager.tsx
@@ -8,7 +8,7 @@ import {
 import IconButton from "@mui/material/IconButton";
 import TableCell from "@mui/material/TableCell";
 import Tooltip from "@mui/material/Tooltip";
-import { AddIcon, DeleteIcon, GenerateBucketsIcon } from "views/common/icons";
+import { AddIcon, DeleteIcon } from "views/common/icons";
 import React from "react";
 import dispatcher from "data/dispatcher";
 import PlanActions from "features/Planner/data/PlanActions";
@@ -17,12 +17,13 @@ import useFluxStore from "data/useFluxStore";
 import { formatLocalDate, parseLocalDate } from "util/time";
 import LocalTextField from "views/common/LocalTextField";
 import getBucketLabel from "features/Planner/components/getBucketLabel";
+import ResetBucketsButton from "./ResetBucketsButton";
 
 const BucketManager = () => {
     const {
+        id: planId,
         buckets,
         onBucketCreate,
-        onBucketReset,
         onBucketNameChange,
         onBucketDateChange,
         onBucketDelete,
@@ -30,15 +31,11 @@ const BucketManager = () => {
         const plan = planStore.getActivePlanRlo().data;
         if (!plan) throw new TypeError("Missing required plan");
         return {
+            id: plan.id,
             buckets: plan.buckets || [],
             onBucketCreate: () =>
                 dispatcher.dispatch({
                     type: PlanActions.CREATE_BUCKET,
-                    planId: plan.id,
-                }),
-            onBucketReset: () =>
-                dispatcher.dispatch({
-                    type: PlanActions.RESET_TO_THIS_WEEKS_BUCKETS,
                     planId: plan.id,
                 }),
             onBucketNameChange: (id, value) =>
@@ -84,18 +81,7 @@ const BucketManager = () => {
                                     <AddIcon />
                                 </IconButton>
                             </Tooltip>
-                            <Tooltip
-                                title="Reset to this week's buckets"
-                                placement="bottom-end"
-                            >
-                                <IconButton
-                                    edge="end"
-                                    onClick={() => onBucketReset()}
-                                    size="small"
-                                >
-                                    <GenerateBucketsIcon />
-                                </IconButton>
-                            </Tooltip>
+                            <ResetBucketsButton planId={planId} edge="end" />
                         </TableCell>
                     </TableRow>
                 </TableHead>

--- a/src/features/Planner/components/ResetBucketsButton.tsx
+++ b/src/features/Planner/components/ResetBucketsButton.tsx
@@ -1,0 +1,29 @@
+import IconButton from "@mui/material/IconButton";
+import dispatcher from "../../../data/dispatcher";
+import PlanActions from "../data/PlanActions";
+import { GenerateBucketsIcon } from "../../../views/common/icons";
+import Tooltip from "@mui/material/Tooltip";
+import React from "react";
+import { BfsId } from "../../../global/types/identity";
+import { IconButtonProps } from "@mui/material";
+
+const ResetBucketsButton: React.FC<{ planId: BfsId } & IconButtonProps> = ({
+    planId,
+    ...props
+}) => (
+    <Tooltip title="Reset to this week's buckets" placement="bottom-end">
+        <IconButton
+            onClick={() =>
+                dispatcher.dispatch({
+                    type: PlanActions.RESET_TO_THIS_WEEKS_BUCKETS,
+                    planId: planId,
+                })
+            }
+            size="small"
+            {...props}
+        >
+            <GenerateBucketsIcon />
+        </IconButton>
+    </Tooltip>
+);
+export default ResetBucketsButton;

--- a/src/features/Planner/components/StatusIconButton.tsx
+++ b/src/features/Planner/components/StatusIconButton.tsx
@@ -30,26 +30,26 @@ interface Props {
     onClick?: MouseEventHandler;
 }
 
-const StatusIconButton: React.FC<Props> = (props) => {
-    const Btn = findButton(props.next, props.current || props.next);
-    const Icn = getIconForStatus(props.next);
+const StatusIconButton: React.FC<Props> = ({ next, current, id, ...props }) => {
+    const Btn = findButton(next, current || next);
+    const Icn = getIconForStatus(next);
     return (
         <Tooltip
-            title={`Mark ${props.next.substring(0, 1)}${props.next
+            title={`Mark ${next.substring(0, 1)}${next
                 .substring(1)
                 .toLowerCase()}`}
             disableInteractive
             enterDelay={750}
         >
             <Btn
-                aria-label={props.next.toLowerCase()}
+                aria-label={next.toLowerCase()}
                 size="small"
                 onClick={(e) => {
                     e.stopPropagation();
                     Dispatcher.dispatch({
                         type: PlanActions.SET_STATUS,
-                        id: props.id,
-                        status: props.next,
+                        id: id,
+                        status: next,
                     });
                 }}
                 {...props}

--- a/src/features/Planner/data/planStore.d.ts
+++ b/src/features/Planner/data/planStore.d.ts
@@ -29,7 +29,7 @@ export interface BasePlanItem {
     subtaskIds?: BfsId[];
     aggregateId?: number;
     componentIds?: number[];
-    bucketId?: number;
+    bucketId?: BfsId;
     // client-side
     _expanded?: boolean;
     _next_status?: PlanItemStatus;

--- a/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
+++ b/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
@@ -177,7 +177,7 @@ const BodyContainer: React.FC<Props> = () => {
                     return (
                         <React.Fragment key={item.id}>
                             {toDraw.map((b) => (
-                                <Bucket key={b.id} bucket={b}></Bucket>
+                                <Bucket key={b.id} bucket={b} />
                             ))}
                             {!item.bucket && plan.buckets.length > 0 && (
                                 <Bucket />
@@ -266,7 +266,7 @@ const PlannedRecipe: React.FC<PlannedRecipeProps> = ({ item }) => {
 export const CurrentPlanSidebar: React.FC<Props> = ({ children }: Props) => {
     return (
         <FlexBox>
-            <div>{children}</div>
+            <div style={{ width: "100%" }}>{children}</div>
             <Sidebar variant="permanent" anchor={"right"}>
                 <BodyContainer />
             </Sidebar>

--- a/src/util/useWhileOver.ts
+++ b/src/util/useWhileOver.ts
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+const useWhileOver = () => {
+    const [over, setOver] = useState(false);
+    const sensorProps = {
+        onMouseEnter: () => setOver(true),
+        onMouseLeave: () => setOver(false),
+    };
+    return {
+        over,
+        sensorProps,
+    };
+};
+
+export default useWhileOver;


### PR DESCRIPTION
Correctly full-width the interim container used to draw the planner sidebar on the recipe library, so searches with less than a row's results don't squish sideways.

Also fix rendering logic to always show all buckets, regardless how recipes are distributed among them.

Offer "reset buckets" in the header, so you don't have to go find the plan sidebar if the defaults are sufficient.