### PR TITLE
Send to long-named plan buttons

### DIFF
--- a/src/features/RecipeLibrary/components/SendToPlan.tsx
+++ b/src/features/RecipeLibrary/components/SendToPlan.tsx
@@ -71,6 +71,7 @@ const SendToPlan: React.FC<Props> = ({
             onClick={handleClick}
             title={`Send to ${list.name}`}
             startIcon={<SendToPlanIcon />}
+            sx={{ maxWidth: "100%" }}
         >
             To {list.name}
         </TextButton>

--- a/src/views/common/SplitButton.tsx
+++ b/src/views/common/SplitButton.tsx
@@ -1,7 +1,6 @@
 import Button from "@mui/material/Button";
 import ButtonGroup, { ButtonGroupOwnProps } from "@mui/material/ButtonGroup";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
-import Grid from "@mui/material/Grid";
 import Grow from "@mui/material/Grow";
 import MenuItem from "@mui/material/MenuItem";
 import MenuList from "@mui/material/MenuList";
@@ -73,79 +72,84 @@ const SplitButton = <TOption,>({
     };
 
     return (
-        <Grid container direction="column" alignItems="center">
-            <Grid item xs={12}>
-                <ButtonGroup
-                    disableElevation={disableElevation}
-                    variant={variant}
-                    ref={anchorRef}
-                    aria-label="split button"
-                    color={color}
+        <>
+            <ButtonGroup
+                disableElevation={disableElevation}
+                variant={variant}
+                ref={anchorRef}
+                aria-label="split button"
+                color={color}
+                sx={{
+                    minWidth: 0,
+                }}
+            >
+                <Button
+                    startIcon={startIcon ? startIcon : null}
+                    size="small"
+                    onClick={handleClick}
+                    disabled={disabled}
                 >
-                    <Button
-                        startIcon={startIcon ? startIcon : null}
-                        size="small"
-                        onClick={handleClick}
-                        disabled={disabled}
-                    >
-                        {primary}
-                    </Button>
-                    <Button
-                        size="small"
-                        onClick={handleToggle}
-                        disabled={
-                            dropdownDisabled || !options || !options.length
-                        }
-                        sx={{
-                            paddingX: 0,
+                    <span
+                        style={{
+                            whiteSpace: "nowrap",
+                            textOverflow: "ellipsis",
+                            overflow: "hidden",
                         }}
                     >
-                        <DropDownIcon />
-                    </Button>
-                </ButtonGroup>
-                <Popper
-                    open={open}
-                    anchorEl={anchorRef.current}
-                    role={undefined}
-                    transition
-                    disablePortal
-                    className={classes.popper}
-                    placement={"bottom-end"}
+                        {primary}
+                    </span>
+                </Button>
+                <Button
+                    size="small"
+                    onClick={handleToggle}
+                    disabled={dropdownDisabled || !options || !options.length}
+                    sx={{
+                        paddingX: 0,
+                    }}
                 >
-                    {({ TransitionProps, placement }) => (
-                        <Grow
-                            {...TransitionProps}
-                            style={{
-                                transformOrigin:
-                                    placement === "bottom"
-                                        ? "right top"
-                                        : "right bottom",
-                            }}
-                        >
-                            <Paper>
-                                <ClickAwayListener onClickAway={handleClose}>
-                                    <MenuList id="split-button-menu">
-                                        {options.map((option) => (
-                                            <MenuItem
-                                                key={option.id}
-                                                selected={
-                                                    option === selectedOption
-                                                }
-                                                onClick={(event) =>
-                                                    handleSelect(event, option)
-                                                }
-                                            >
-                                                {option.label}
-                                            </MenuItem>
-                                        ))}
-                                    </MenuList>
-                                </ClickAwayListener>
-                            </Paper>
-                        </Grow>
-                    )}
-                </Popper>
-            </Grid>
-        </Grid>
+                    <DropDownIcon />
+                </Button>
+            </ButtonGroup>
+            <Popper
+                open={open}
+                anchorEl={anchorRef.current}
+                role={undefined}
+                transition
+                disablePortal
+                className={classes.popper}
+                placement={"bottom-end"}
+            >
+                {({ TransitionProps, placement }) => (
+                    <Grow
+                        {...TransitionProps}
+                        style={{
+                            transformOrigin:
+                                placement === "bottom"
+                                    ? "right top"
+                                    : "right bottom",
+                        }}
+                    >
+                        <Paper>
+                            <ClickAwayListener onClickAway={handleClose}>
+                                <MenuList id="split-button-menu">
+                                    {options.map((option) => (
+                                        <MenuItem
+                                            key={option.id}
+                                            selected={option === selectedOption}
+                                            onClick={(event) =>
+                                                handleSelect(event, option)
+                                            }
+                                        >
+                                            {option.label}
+                                        </MenuItem>
+                                    ))}
+                                </MenuList>
+                            </ClickAwayListener>
+                        </Paper>
+                    </Grow>
+                )}
+            </Popper>
+        </>
     );
 };
 


### PR DESCRIPTION
Clean up the split button's flexbox so it can collapse the button text if it's too wide. The majority of the diff is the resulting de-indent. Constrain the recipe detail button so its container's width (it already had the text collapse).

<img width="286" alt="image" src="https://github.com/user-attachments/assets/80419e83-cb38-41ba-9203-84c0441d4c9a">

<img width="608" alt="image" src="https://github.com/user-attachments/assets/e057f1bd-a906-4de0-b077-46fbc6ec442a">

closes #175 