### PR TITLE
use code instead of span, and strip extra leading newline

### DIFF
--- a/src/views/common/Markdown.tsx
+++ b/src/views/common/Markdown.tsx
@@ -26,25 +26,29 @@ const Markdown: React.FC<Props> = ({ text }) => {
                         while ((start = lines.indexOf("```diff", prev)) >= 0) {
                             const end = lines.indexOf("```", start + 1);
                             if (end < 0) break;
-                            lines[start] = `<pre class="diff">`;
+                            lines[start] = `<pre class="diff language-diff">`;
                             lines[end] = `</pre>`;
                             for (let i = start + 1; i < end; i++) {
                                 const l = lines[i];
                                 if (l.startsWith("@@")) {
                                     lines[
                                         i
-                                    ] = `<span class="range">${l}</span>`;
+                                    ] = `<code class="range">${l}</code>`;
                                 } else if (l.startsWith("+")) {
                                     lines[
                                         i
-                                    ] = `<span class="inserted">${l}</span>`;
+                                    ] = `<code class="inserted">${l}</code>`;
                                 } else if (l.startsWith("-")) {
                                     lines[
                                         i
-                                    ] = `<span class="deleted">${l}</span>`;
+                                    ] = `<code class="deleted">${l}</code>`;
                                 }
                             }
-                            prev = end + 1;
+                            // Combine the start and first line, to avoid the
+                            // extra line break from the nested <code> tag.
+                            lines[start] += lines[start + 1];
+                            lines.splice(start + 1, 1);
+                            prev = end;
                         }
                         return lines.join("\n");
                     },


### PR DESCRIPTION
The `pre` tag will suppress a line break immediately following it, if the next character is text. If, however, a tag follows the newline, the newline is preserved. The nested highlight means the latter case triggers, so unwrap the first line.