### PR TITLE
 new version banner doesnt reflow w the new library sidebar

### DIFF
--- a/src/RoutingSwitch.tsx
+++ b/src/RoutingSwitch.tsx
@@ -1,14 +1,17 @@
-import PropTypes from "prop-types";
 import { Switch, useLocation } from "react-router-dom";
-import { useIsAuthenticated } from "@/providers/Profile";
 import FluxRoute from "./views/common/FluxRoute";
 import NotFound from "./views/common/NotFound";
 import PrivateRoute from "./views/common/PrivateRoute";
 import Login from "./views/user/Login";
+import React from "react";
+import { BfsRoutes } from "@/routes";
 
-function RoutingSwitch(props) {
-    const { routes } = props;
-    const authenticated = useIsAuthenticated();
+export interface SwitchProps {
+    readonly routes: BfsRoutes;
+    readonly authenticated: boolean;
+}
+
+const RoutingSwitch: React.FC<SwitchProps> = ({ routes, authenticated }) => {
     const location = useLocation();
 
     return (
@@ -44,20 +47,6 @@ function RoutingSwitch(props) {
             <FluxRoute component={NotFound} />
         </Switch>
     );
-}
-
-const routeType = PropTypes.shape({
-    path: PropTypes.string.isRequired,
-    component: PropTypes.elementType.isRequired,
-    exact: PropTypes.bool,
-});
-
-RoutingSwitch.propTypes = {
-    authenticated: PropTypes.bool.isRequired,
-    routes: PropTypes.shape({
-        public: PropTypes.arrayOf(routeType),
-        private: PropTypes.arrayOf(routeType),
-    }).isRequired,
 };
 
 export default RoutingSwitch;

--- a/src/SidebarSwitch.tsx
+++ b/src/SidebarSwitch.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { SwitchProps } from "@/RoutingSwitch";
+import { Route, Switch } from "react-router-dom";
+
+const SidebarSwitch: React.FC<SwitchProps> = ({ routes, authenticated }) => {
+    // Don't move the conditional inside render up to here (or a .filter)! It's
+    // important the same <Route> are rendered here as for the main content, so
+    // sidebars use the same scoping. Otherwise, you get weird 'exact' effects.
+    const children = routes.private.map((route) => (
+        <Route
+            key={route.path}
+            path={route.path}
+            render={(props) =>
+                route.sidebar ? (
+                    <route.sidebar authenticated={authenticated} {...props} />
+                ) : null
+            }
+            exact={route.exact}
+        />
+    ));
+    return <Switch>{children}</Switch>;
+};
+
+export default SidebarSwitch;

--- a/src/features/Navigation/NavigationController.tsx
+++ b/src/features/Navigation/NavigationController.tsx
@@ -18,6 +18,8 @@ import ShoppingActions from "@/data/ShoppingActions";
 import PlanActions from "../Planner/data/PlanActions";
 import useIsNavCollapsed, { setNavCollapsed } from "@/data/useIsNavCollapsed";
 import { BfsId } from "@/global/types/identity";
+import routes from "@/routes";
+import SidebarSwitch from "@/SidebarSwitch";
 
 type NavigationControllerProps = {
     authenticated: boolean;
@@ -119,6 +121,7 @@ export const NavigationController: React.FC<NavigationControllerProps> = ({
                 onExpand={handleExpand}
             />
             <MainDesktop open={expanded}>{children}</MainDesktop>
+            <SidebarSwitch routes={routes} authenticated={authenticated} />
         </FlexBox>
     );
 };

--- a/src/features/RecipeEdit/components/TextractButton.tsx
+++ b/src/features/RecipeEdit/components/TextractButton.tsx
@@ -2,12 +2,13 @@ import { Box, Button } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { LibraryIcon, TextractIcon } from "@/views/common/icons";
 import React, { MouseEventHandler } from "react";
+import { Theme } from "@mui/material/styles";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
     trigger: {
         position: "absolute",
         right: 0,
-        zIndex: 1000,
+        zIndex: theme.zIndex.fab,
         backgroundColor: theme.palette.background.paper,
         transformOrigin: "bottom right",
         transform: `rotate(90deg) translateY(100%) translateX(50%)`,

--- a/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
+++ b/src/features/RecipeLibrary/components/CurrentPlanSidebar.tsx
@@ -1,5 +1,4 @@
-import { FlexBox } from "@/global/components/FlexBox";
-import React, { PropsWithChildren, ReactElement } from "react";
+import React, { ReactElement } from "react";
 import { CSSObject, styled } from "@mui/material/styles";
 import {
     Drawer,
@@ -30,9 +29,7 @@ import { moveSubtree } from "@/features/Planner/components/Plan";
 import ResetBucketsButton from "@/features/Planner/components/ResetBucketsButton";
 import useWhileOver from "@/util/useWhileOver";
 
-type Props = PropsWithChildren<unknown>;
-
-export const drawerWidth = 200;
+const drawerWidth = 200;
 const BUCKET_PREFIX = "bucket-";
 
 const openedMixin: CSSObject = {
@@ -75,7 +72,7 @@ type PlanInfo = Pick<TPlan, "id" | "name" | "buckets"> & {
     recipes: RecipeInfo[];
 };
 
-const BodyContainer: React.FC<Props> = () => {
+const BodyContainer: React.FC = () => {
     const plan = useFluxStore<Maybe<PlanInfo>>(() => {
         const { data: plan, loading } = planStore.getActivePlanRlo();
         if (!plan || loading) return;
@@ -272,13 +269,10 @@ const PlannedRecipe: React.FC<PlannedRecipeProps> = ({ item }) => {
     );
 };
 
-export const CurrentPlanSidebar: React.FC<Props> = ({ children }: Props) => {
+export const CurrentPlanSidebar: React.FC = () => {
     return (
-        <FlexBox>
-            <div style={{ width: "100%" }}>{children}</div>
-            <Sidebar variant="permanent" anchor={"right"}>
-                <BodyContainer />
-            </Sidebar>
-        </FlexBox>
+        <Sidebar variant="permanent" anchor={"right"}>
+            <BodyContainer />
+        </Sidebar>
     );
 };

--- a/src/features/RecipeLibrary/components/RecipesList.tsx
+++ b/src/features/RecipeLibrary/components/RecipesList.tsx
@@ -12,8 +12,6 @@ import LoadingIndicator from "@/views/common/LoadingIndicator";
 import { LibrarySearchScope } from "@/__generated__/graphql";
 import { MessagePaper } from "@/features/RecipeLibrary/components/MessagePaper";
 import { SearchRecipes } from "@/features/RecipeLibrary/components/SearchRecipes";
-import useIsDevMode from "@/data/useIsDevMode";
-import { CurrentPlanSidebar, drawerWidth } from "./CurrentPlanSidebar";
 
 interface RecipesListProps {
     me: any; // todo
@@ -43,7 +41,6 @@ export const RecipesList: React.FC<RecipesListProps> = ({
         threshold: 15,
     });
     const isMobile = useIsMobile();
-    const devMode = useIsDevMode();
     const [unsavedFilter, setUnsavedFilter] = useState(filter);
 
     function handleSearchChange(e) {
@@ -146,18 +143,10 @@ export const RecipesList: React.FC<RecipesListProps> = ({
         </>
     );
 
-    let fabSx: any = undefined;
-    if (!isMobile && devMode) {
-        fabSx = {
-            right: (theme) => `calc(${theme.spacing(2)} + ${drawerWidth}px)`,
-        };
-        body = <CurrentPlanSidebar>{body}</CurrentPlanSidebar>;
-    }
-
     return (
         <Content disableGutters={!isMobile}>
             {body}
-            <FoodingerFab onClick={() => history.push(`/add`)} sx={fabSx}>
+            <FoodingerFab onClick={() => history.push(`/add`)}>
                 <AddRecipeIcon />
             </FoodingerFab>
         </Content>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,7 +2,7 @@ import { Redirect, RouteProps } from "react-router-dom";
 import { PlannerController as Planner } from "@/features/Planner/PlannerController";
 import PlannedBucketController from "./features/RecipeDisplay/PlannedBucketController";
 import PlannedRecipeController from "./features/RecipeDisplay/PlannedRecipeController";
-import Recipe from "./features/RecipeDisplay/RecipeController";
+import RecipeController from "./features/RecipeDisplay/RecipeController";
 import RecipeEditController from "./features/RecipeEdit/RecipeEditController";
 import Shop from "./containers/Shop";
 import { SharedRecipeController } from "./features/RecipeDisplay/SharedRecipeController";
@@ -12,10 +12,11 @@ import { UserProfileView } from "@/views/UserProfile/UserProfileView";
 import Profile from "./views/user/Profile";
 import Foodinger from "@/views/Foodinger";
 import { RecipeAddController } from "./features/RecipeEdit/RecipeAddController";
-import { Library } from "@/views/Library";
 import PantryItemAdmin from "./features/PantryItemAdmin/PantryItemAdmin";
+import { CurrentPlanSidebar } from "@/features/RecipeLibrary/components/CurrentPlanSidebar";
 import * as React from "react";
 import { RouteComponentProps } from "react-router";
+import { LibraryController } from "@/features/RecipeLibrary/LibraryController";
 
 interface BfsRouteComponentProps extends RouteComponentProps {
     readonly authenticated: boolean;
@@ -34,9 +35,14 @@ export interface BfsRoute extends RouteProps {
     readonly component: BfsRouteComponent;
 }
 
+interface PrivateBfsRoute extends BfsRoute {
+    // sidebars are not supported on mobile (as you'd expect).
+    readonly sidebar?: BfsRouteComponent | undefined;
+}
+
 export interface BfsRoutes {
     readonly public: BfsRoute[];
-    readonly private: BfsRoute[];
+    readonly private: PrivateBfsRoute[];
 }
 
 const routes: BfsRoutes = {
@@ -57,8 +63,16 @@ const routes: BfsRoutes = {
             path: "/library/recipe/:id/make-copy",
             component: RecipeEditController,
         },
-        { path: "/library/recipe/:id", component: Recipe },
-        { path: "/library", component: Library },
+        {
+            path: "/library/recipe/:id",
+            component: RecipeController,
+            sidebar: CurrentPlanSidebar,
+        },
+        {
+            path: "/library",
+            component: LibraryController,
+            sidebar: CurrentPlanSidebar,
+        },
         { path: "/add", component: RecipeAddController },
         // eslint-disable-next-line react/display-name
         { path: "/tasks", component: () => <Redirect to="/plan" /> },

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,4 @@
-import { Redirect } from "react-router-dom";
+import { Redirect, RouteProps } from "react-router-dom";
 import { PlannerController as Planner } from "@/features/Planner/PlannerController";
 import PlannedBucketController from "./features/RecipeDisplay/PlannedBucketController";
 import PlannedRecipeController from "./features/RecipeDisplay/PlannedRecipeController";
@@ -14,8 +14,32 @@ import Foodinger from "@/views/Foodinger";
 import { RecipeAddController } from "./features/RecipeEdit/RecipeAddController";
 import { Library } from "@/views/Library";
 import PantryItemAdmin from "./features/PantryItemAdmin/PantryItemAdmin";
+import * as React from "react";
+import { RouteComponentProps } from "react-router";
 
-const routes = {
+interface BfsRouteComponentProps extends RouteComponentProps {
+    readonly authenticated: boolean;
+}
+
+// Don't allow an undefined component. Not sure why that'd be useful.
+type BfsRouteComponent =
+    | React.ComponentType<BfsRouteComponentProps>
+    | React.ComponentType<any>;
+
+export interface BfsRoute extends RouteProps {
+    // React Router allows a string[], but we don't use that. We do, however use
+    // paths as keys, which must be string. Express that here, as well as that
+    // a path is required and cannot be null/undefined. At least for now. :)
+    readonly path: string;
+    readonly component: BfsRouteComponent;
+}
+
+export interface BfsRoutes {
+    readonly public: BfsRoute[];
+    readonly private: BfsRoute[];
+}
+
+const routes: BfsRoutes = {
     public: [
         { path: "/", component: Landing, exact: true },
         { path: "/foodinger", component: Foodinger },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -84,6 +84,11 @@ const baseTokens: ThemeOptions = {
             marginBottom: ".5em",
         },
     },
+    zIndex: {
+        // These place the FAB above drawer
+        fab: 1250,
+        speedDial: 1250,
+    },
 };
 
 const lightTokens: ThemeOptions = {

--- a/src/views/Library.tsx
+++ b/src/views/Library.tsx
@@ -1,6 +1,0 @@
-import * as React from "react";
-import { LibraryController } from "@/features/RecipeLibrary/LibraryController";
-
-export const Library: React.FC = () => {
-    return <LibraryController />;
-};

--- a/src/views/common/PrivateRoute.tsx
+++ b/src/views/common/PrivateRoute.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import React from "react";
 import { Redirect } from "react-router-dom";
 import {
     useIsProfileInitializing,
@@ -8,11 +8,12 @@ import {
 import FluxRoute from "./FluxRoute";
 import LoadingIndicator from "./LoadingIndicator";
 import { Location } from "history";
+import { BfsRoute } from "@/routes";
 
-function AuthenticatedHelper({ render, ...rest }) {
+function AuthenticatedHelper({ render, ...route }) {
     return render({
         currentUser: useProfile(),
-        ...rest,
+        ...route,
     });
 }
 
@@ -30,29 +31,27 @@ const AnonymousHelper: React.FC<{ location: Location }> = ({ location }) => {
     );
 };
 
-interface Props {
+interface Props extends BfsRoute {
     authenticated: boolean;
-    component: ComponentType;
-    location: Location;
 }
 
 const PrivateRoute: React.FC<Props> = ({
     component: Component,
     authenticated,
-    ...rest
+    ...route
 }) => {
     if (useIsProfilePending()) {
         return <LoadingIndicator />;
     }
     return (
         <FluxRoute
-            {...rest}
+            {...route}
             render={(props) => {
                 if (authenticated) {
                     return (
                         <AuthenticatedHelper
                             render={(props) => <Component {...props} />}
-                            {...rest}
+                            {...route}
                             {...props}
                         />
                     );


### PR DESCRIPTION
The new version banner flowed poorly because the sidebar was at a nonsensical location in the DOM tree. To get it in the right location, I opted to use the router, so private routes can declare a `sidebar` next to their main `component`, and it'll be automatically added at the right place in the DOM. This is accomplished via `SidebarSwitch` in `NavigationController`.

This has two side effects:

1. the planner sidebar is no longer behind the devMode flag, and
1. the FAB is now back where it's always been, which is now atop the drawer.

Closes #196 