### PR TITLE
Include photo on copy

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -104,10 +104,24 @@ type LabelsQuery {
 }
 
 type LibraryMutation {
+    "Create a new recipe in your library, from the passed info."
     createRecipe(cookThis: Boolean, info: IngredientInfo!, photo: Upload): Recipe!
+    """
+
+    Create a new recipe in your library, from the passed info, which is based
+    on the passed source recipe id.
+    """
+    createRecipeFrom(info: IngredientInfo!, photo: Upload, sourceRecipeId: ID!): Recipe!
+    "Delete a recipe from your library."
     deleteRecipe(id: ID!): Deletion!
     history(recipeId: ID!): RecipeHistoryMutation
+    """
+
+    Set the photo for a recipe in your library, without changing any other
+    info about the recipe. A photo may be set during create and/or update.
+    """
     setRecipePhoto(id: ID!, photo: Upload!): Recipe!
+    "Update a recipe in your library, from the passed info."
     updateRecipe(id: ID!, info: IngredientInfo!, photo: Upload): Recipe!
 }
 

--- a/src/data/hooks/useCreateRecipeFrom.ts
+++ b/src/data/hooks/useCreateRecipeFrom.ts
@@ -1,0 +1,52 @@
+import { useMutation } from "@apollo/client";
+import { DraftRecipe } from "@/global/types/types";
+import { gql } from "@/__generated__";
+import { GetSearchLibraryDocument } from "@/__generated__/graphql";
+import promiseWellSizedFile from "@/util/promiseWellSizedFile";
+import { recipeToIngredientInfo } from "@/data/utils/graphql";
+
+const CREATE_RECIPE_FROM_MUTATION = gql(`
+mutation createRecipeFrom($sourceRecipeId: ID!
+  , $info: IngredientInfo!
+  , $photo: Upload
+) {
+  library {
+    createRecipeFrom(sourceRecipeId: $sourceRecipeId
+      , info: $info
+      , photo: $photo
+      ) {
+      id
+    }
+  }
+}
+`);
+
+export const useCreateRecipeFrom = () => {
+    const [mutateFunction, { data, loading, error }] = useMutation(
+        CREATE_RECIPE_FROM_MUTATION,
+        { refetchQueries: [GetSearchLibraryDocument] },
+    );
+
+    const createRecipeFrom = async (recipe: DraftRecipe) => {
+        let sizedUpload: File | string | null = null;
+
+        if (recipe.photoUpload) {
+            sizedUpload = await promiseWellSizedFile(recipe.photoUpload);
+        }
+
+        return mutateFunction({
+            variables: {
+                sourceRecipeId: recipe.id.toString(),
+                info: recipeToIngredientInfo(recipe),
+                photo: typeof sizedUpload !== "string" ? sizedUpload : null,
+            },
+        });
+    };
+
+    return {
+        createRecipeFrom,
+        data,
+        error,
+        loading,
+    };
+};

--- a/src/data/hooks/useRecipeForm.ts
+++ b/src/data/hooks/useRecipeForm.ts
@@ -17,28 +17,28 @@ type UseRecipeFormReturn = {
     onMultilinePasteIngredientRefs: (idx: number, text: string) => void;
 };
 
-export function useRecipeForm(recipe: Recipe): UseRecipeFormReturn {
-    const buildDraft = (recipe: Recipe) => {
-        return {
-            ...recipe,
-            ingredients: recipe.ingredients.map((ing) => ({
-                ...ing,
-                id: ClientId.next(),
-            })),
-            photoUrl: recipe.photo,
-            photoUpload: null,
-            sourceId: null,
-        };
+const buildDraft = (recipe: Recipe) => {
+    return {
+        ...recipe,
+        ingredients: recipe.ingredients.map((ing) => ({
+            ...ing,
+            id: ClientId.next(),
+        })),
+        photoUrl: recipe.photo,
+        photoUpload: null,
+        sourceId: null,
     };
+};
 
-    const buildNewIngredient = (raw?: string) => ({
-        id: ClientId.next(),
-        raw: raw || "",
-        ingredient: null,
-        preparation: null,
-        quantity: null,
-    });
+const buildNewIngredient = (raw?: string) => ({
+    id: ClientId.next(),
+    raw: raw || "",
+    ingredient: null,
+    preparation: null,
+    quantity: null,
+});
 
+export function useRecipeForm(recipe: Recipe): UseRecipeFormReturn {
     const [draft, setDraft] = React.useState<DraftRecipe>(buildDraft(recipe));
 
     const onUpdate = (key: string, value: FormValue) => {

--- a/src/features/RecipeEdit/RecipeEditController.tsx
+++ b/src/features/RecipeEdit/RecipeEditController.tsx
@@ -8,7 +8,7 @@ import RecipeForm from "@/features/RecipeEdit/components/RecipeForm";
 import DeleteButton from "@/views/common/DeleteButton";
 import { Alert, CircularProgress } from "@mui/material";
 import { useUpdateRecipe } from "@/data/hooks/useUpdateRecipe";
-import { useCreateRecipe } from "@/data/hooks/useCreateRecipe";
+import { useCreateRecipeFrom } from "@/data/hooks/useCreateRecipeFrom";
 import type { BfsId } from "@/global/types/identity";
 import type { DraftRecipe } from "@/global/types/types";
 import { useDeleteRecipe } from "@/data/hooks/useDeleteRecipe";
@@ -22,7 +22,7 @@ const RecipeEditController: React.FC<Props> = ({ match }) => {
     const { loading, data: recipe } = useGetRecipe(id);
     const { data: labelList } = useGetAllLabels();
     const { error: updateError, updateRecipe } = useUpdateRecipe();
-    const { error: createError, createRecipe } = useCreateRecipe();
+    const { error: createError, createRecipeFrom } = useCreateRecipeFrom();
     const myProfileId = useProfileId();
     const [deleteRecipe] = useDeleteRecipe();
 
@@ -57,8 +57,8 @@ const RecipeEditController: React.FC<Props> = ({ match }) => {
     };
 
     const handleSaveCopy = (recipe: DraftRecipe) => {
-        createRecipe(recipe).then((result) => {
-            const id = result.data?.library?.createRecipe.id;
+        createRecipeFrom(recipe).then((result) => {
+            const id = result.data?.library?.createRecipeFrom.id;
             id
                 ? history.push(`/library/recipe/${id}`)
                 : history.push(`/library`);

--- a/src/views/ElEdit.tsx
+++ b/src/views/ElEdit.tsx
@@ -1,4 +1,4 @@
-import { Grid, InputAdornment, TextField } from "@mui/material";
+import { Autocomplete, Grid, InputAdornment, TextField } from "@mui/material";
 import { ErrorIcon, OkIcon } from "./common/icons";
 import React, { PropsWithChildren } from "react";
 import ItemApi, { RecognitionResult } from "@/data/ItemApi";
@@ -6,7 +6,6 @@ import debounce from "@/util/debounce";
 import processRecognizedItem from "@/util/processRecognizedItem";
 import type { IngredientRef } from "@/global/types/types";
 import { BfsId } from "@/global/types/identity";
-import Autocomplete from "@mui/lab/Autocomplete";
 import LoadingIconButton from "./common/LoadingIconButton";
 
 const doRecog = (raw) => raw != null && raw.trim().length >= 2;


### PR DESCRIPTION
Client-side to leverage folded-ear/gobrennas-api#95's new `createRecipeFrom` mutation, which will copy the photo  from the source recipe, if the new recipe doesn't supply its own.

closes #103 