### PR TITLE
Sidebar cook view

### DIFF
--- a/src/features/Planner/components/CookButton.tsx
+++ b/src/features/Planner/components/CookButton.tsx
@@ -1,10 +1,10 @@
-import { IconButton, Tooltip } from "@mui/material";
+import { IconButton, IconButtonProps, Tooltip } from "@mui/material";
 import { CookIcon } from "@/views/common/icons";
 import React from "react";
 import history from "@/util/history";
 import { BfsId } from "@/global/types/identity";
 
-interface Props {
+interface Props extends IconButtonProps {
     planId: BfsId;
     itemId: BfsId;
 }

--- a/src/features/Planner/components/PlanItemBucketChip.tsx
+++ b/src/features/Planner/components/PlanItemBucketChip.tsx
@@ -17,8 +17,8 @@ interface BucketChipProps {
     buckets: PlanBucket[];
     onSelect(bucketId: Maybe<BfsId>): void;
     onManage?: () => void;
-    offPlan: boolean;
-    size: ChipProps["size"];
+    offPlan?: boolean;
+    size?: ChipProps["size"];
 }
 
 const BucketChip: React.FC<BucketChipProps> = ({

--- a/src/features/Planner/components/StatusIconButton.tsx
+++ b/src/features/Planner/components/StatusIconButton.tsx
@@ -1,5 +1,4 @@
-import { IconButton, Tooltip } from "@mui/material";
-import React, { MouseEventHandler } from "react";
+import { IconButton, IconButtonProps, Tooltip } from "@mui/material";
 import Dispatcher from "@/data/dispatcher";
 import PlanActions from "@/features/Planner/data/PlanActions";
 import PlanItemStatus, {
@@ -26,14 +25,13 @@ function findButton(
     return buttonLookup[next][curr];
 }
 
-interface Props {
+interface Props extends Omit<IconButtonProps, "id"> {
     next: PlanItemStatus;
     current?: PlanItemStatus;
     id?: BfsId;
-    onClick?: MouseEventHandler;
 }
 
-const StatusIconButton: React.FC<Props> = ({ next, current, id, ...props }) => {
+const StatusIconButton = ({ next, current, id, ...props }: Props) => {
     const Btn = findButton(next, current || next);
     const Icn = getIconForStatus(next);
     return (


### PR DESCRIPTION
Add a cook view button to the planner sidebar on the library. Clean up some types and convert the plan's `PlanItem` component along the way.

closes #200 