### PR TITLE
Route buttons

### DIFF
--- a/src/features/Favorites/components/Indicator.tsx
+++ b/src/features/Favorites/components/Indicator.tsx
@@ -30,7 +30,12 @@ const Indicator: React.FC<Props> = ({ type, id }) => {
     }
 
     return (
-        <TaskBarButton edge="start" size="small" onClick={handleClick}>
+        <TaskBarButton
+            edge="start"
+            size="small"
+            onClick={handleClick}
+            style={{ backgroundColor: "unset" }}
+        >
             {favorite ? <FavoriteIcon /> : <NotFavoriteIcon />}
         </TaskBarButton>
     );

--- a/src/features/LibrarySearch/components/RecipeListItem.tsx
+++ b/src/features/LibrarySearch/components/RecipeListItem.tsx
@@ -15,6 +15,7 @@ import {
     SmallHeadline,
     SmallLabel,
 } from "@/global/elements/typography.elements";
+import { Link } from "react-router-dom";
 
 type RecipeListItemProps = {
     recipe: RecipeType;
@@ -62,12 +63,16 @@ export const RecipeListItem: React.FC<RecipeListItemProps> = ({
                 <TaskBar>
                     <FavoriteIndicator type={"Recipe"} id={recipe.id} />
                     <SendToPlan iconOnly onClick={handleClick} />
-                    <TaskBarButton href={`/library/recipe/${recipe.id}`}>
+                    <TaskBarButton
+                        component={Link}
+                        to={`/library/recipe/${recipe.id}`}
+                    >
                         <ViewIcon />
                     </TaskBarButton>
                     {mine && (
                         <TaskBarButton
-                            href={`/library/recipe/${recipe.id}/edit`}
+                            component={Link}
+                            to={`/library/recipe/${recipe.id}/edit`}
                         >
                             <EditIcon />
                         </TaskBarButton>

--- a/src/features/RecipeLibrary/components/RecipeCard.tsx
+++ b/src/features/RecipeLibrary/components/RecipeCard.tsx
@@ -168,12 +168,16 @@ const RecipeCard: React.FC<Props> = ({ recipe, mine, indicateMine, me }) => {
             </>
             <CardActions>
                 <TaskBar>
-                    <TaskBarButton href={`/library/recipe/${recipe.id}`}>
+                    <TaskBarButton
+                        component={Link}
+                        to={`/library/recipe/${recipe.id}`}
+                    >
                         <ViewIcon />
                     </TaskBarButton>
                     {mine && (
                         <TaskBarButton
-                            href={`/library/recipe/${recipe.id}/edit`}
+                            component={Link}
+                            to={`/library/recipe/${recipe.id}/edit`}
                         >
                             <EditIcon fontSize="inherit" />
                         </TaskBarButton>


### PR DESCRIPTION
The view/edit buttons on recipe cards lost their route/link behavior when they got taskbar-ified. Put it back, to avoid app reloads on navigation.