### PR TITLE
move nanocard image to right and don't let it disappear

### DIFF
--- a/src/features/LibrarySearch/components/RecipeDisplay.elements.tsx
+++ b/src/features/LibrarySearch/components/RecipeDisplay.elements.tsx
@@ -1,10 +1,6 @@
 import { styled } from "@mui/material/styles";
 import { Box, Card } from "@mui/material";
 
-export const Item = styled("div")({
-    border: `1px solid red`,
-});
-
 export const SearchResults = styled(Box)(({ theme }) => ({
     marginTop: theme.spacing(2),
     padding: `0 ${theme.spacing(2)}`,
@@ -12,12 +8,14 @@ export const SearchResults = styled(Box)(({ theme }) => ({
 
 export const NanoRecipeCard = styled(Card)(({ theme }) => ({
     display: "flex",
-    border: `1px solid ${theme.palette.grey["600"]}`,
     borderRadius: theme.shape.borderRadius,
+    backgroundColor: theme.palette.background.default,
 }));
 
 export const NanoCardContent = styled("div")(({ theme }) => ({
     padding: theme.spacing(1),
     display: "flex",
+    width: "80%",
     flexDirection: "column",
+    backgroundColor: theme.palette.background.paper,
 }));

--- a/src/features/LibrarySearch/components/RecipeListDisplay.tsx
+++ b/src/features/LibrarySearch/components/RecipeListDisplay.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Stack } from "@mui/material";
 import { RecipeListItem } from "@/features/LibrarySearch/components/RecipeListItem";
 import { UserType } from "@/global/types/identity";
 import { MessagePaper } from "@/features/RecipeLibrary/components/MessagePaper";
@@ -21,7 +21,7 @@ export const RecipeListDisplay: React.FC<RecipeListDisplayProps> = ({
     }
 
     return (
-        <Box sx={{ display: "flex", gap: `8px`, flexDirection: "column" }}>
+        <Stack gap={1.5}>
             {recipes.map((recipe) => (
                 <RecipeListItem
                     key={recipe.id}
@@ -30,6 +30,6 @@ export const RecipeListDisplay: React.FC<RecipeListDisplayProps> = ({
                     markAsMine={markAsMine}
                 />
             ))}
-        </Box>
+        </Stack>
     );
 };

--- a/src/features/LibrarySearch/components/RecipeListItem.tsx
+++ b/src/features/LibrarySearch/components/RecipeListItem.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { EditIcon, ViewIcon } from "@/views/common/icons";
-import { Box, CardMedia } from "@mui/material";
+import { Box } from "@mui/material";
 import Dispatcher from "@/data/dispatcher";
 import RecipeActions from "@/data/RecipeActions";
 import SendToPlan from "@/features/RecipeLibrary/components/SendToPlan";
@@ -16,6 +16,7 @@ import {
     SmallLabel,
 } from "@/global/elements/typography.elements";
 import { Link } from "react-router-dom";
+import ItemImage from "@/features/RecipeLibrary/components/ItemImage";
 
 type RecipeListItemProps = {
     recipe: RecipeType;
@@ -49,8 +50,7 @@ export const RecipeListItem: React.FC<RecipeListItemProps> = ({
             onMouseLeave={() => setRaised(false)}
         >
             {recipe.photo && recipe.photo.url && (
-                <CardMedia
-                    component="img"
+                <ItemImage
                     sx={{
                         width: "20%",
                         order: 2,
@@ -58,6 +58,7 @@ export const RecipeListItem: React.FC<RecipeListItemProps> = ({
                     }}
                     image={recipe.photo.url}
                     alt={recipe.name}
+                    focus={recipe.photo.focus}
                 />
             )}
             <NanoCardContent>

--- a/src/features/LibrarySearch/components/RecipeListItem.tsx
+++ b/src/features/LibrarySearch/components/RecipeListItem.tsx
@@ -52,7 +52,8 @@ export const RecipeListItem: React.FC<RecipeListItemProps> = ({
                 <CardMedia
                     component="img"
                     sx={{
-                        width: 50,
+                        width: "20%",
+                        order: 2,
                         overflow: "hidden",
                     }}
                     image={recipe.photo.url}

--- a/src/features/LibrarySearch/components/SearchInput.tsx
+++ b/src/features/LibrarySearch/components/SearchInput.tsx
@@ -1,6 +1,6 @@
 import InputBase from "@mui/material/Input";
-import { useState } from "react";
 import * as React from "react";
+import { useState } from "react";
 import { SearchScope } from "@/features/LibrarySearch/types";
 import { IconButton, InputAdornment, Toolbar } from "@mui/material";
 import { ClearIcon, SearchIcon } from "@/views/common/icons";
@@ -47,7 +47,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
     return (
         <Toolbar>
             <InputBase
-                placeholder="Search Recipes"
+                placeholder="Search My Recipes"
                 value={searchText}
                 onChange={handleSearchChange}
                 autoFocus

--- a/src/features/Planner/components/Sidebar.tsx
+++ b/src/features/Planner/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Box, Drawer as MuiDrawer, Paper, Tab, Tabs } from "@mui/material";
+import { Box, Drawer as MuiDrawer, Tab, Tabs } from "@mui/material";
 import { SIDEBAR_DEFAULT_WIDTH } from "@/global/constants";
 import { styled } from "@mui/material/styles";
 import {
@@ -13,18 +13,17 @@ import { BodyContainer } from "@/features/RecipeLibrary/components/CurrentPlanSi
 import { LibrarySearchController } from "@/features/LibrarySearch/LibrarySearchController";
 import useIsDevMode from "@/data/useIsDevMode";
 
-const Drawer = styled(MuiDrawer)(({ theme }) => ({
+const Drawer = styled(MuiDrawer)({
     width: SIDEBAR_DEFAULT_WIDTH,
     flexShrink: 0,
     whiteSpace: "nowrap",
     boxSizing: "border-box",
     "& .MuiDrawer-paper": {
         width: SIDEBAR_DEFAULT_WIDTH,
-        padding: theme.spacing(2),
         height: "100vh",
         overflowX: "hidden",
     },
-})) as typeof MuiDrawer;
+}) as typeof MuiDrawer;
 
 type SidebarDrawerProps = React.PropsWithChildren;
 
@@ -62,16 +61,12 @@ export const SidebarDrawer: React.FC<SidebarDrawerProps> = () => {
         <Drawer variant="permanent" anchor="right">
             <Switch>
                 <Route path={`/plan/:pid/buckets`}>
-                    <Paper>
-                        <SidebarNav />
-                        <BodyContainer />
-                    </Paper>
+                    <SidebarNav />
+                    <BodyContainer />
                 </Route>
                 <Route path={`/plan/:pid`}>
-                    <Paper>
-                        <SidebarNav />
-                        <LibrarySearchController />
-                    </Paper>
+                    <SidebarNav />
+                    <LibrarySearchController />
                 </Route>
             </Switch>
         </Drawer>

--- a/src/features/RecipeDisplay/components/RecipeDetail.tsx
+++ b/src/features/RecipeDisplay/components/RecipeDetail.tsx
@@ -123,9 +123,9 @@ const RecipeDetail: React.FC<Props> = ({
                     {photo ? (
                         <ItemImage
                             className={classes.imageContainer}
-                            url={photo.url}
+                            image={photo.url}
                             focus={photo.focus}
-                            title={recipe.name}
+                            alt={recipe.name}
                         />
                     ) : (
                         <ItemImageUpload

--- a/src/features/RecipeEdit/components/RecipeForm.tsx
+++ b/src/features/RecipeEdit/components/RecipeForm.tsx
@@ -169,10 +169,6 @@ const RecipeForm: React.FC<Props> = ({
                             onImage={(file) => onUpdate("photoUpload", file)}
                             style={{
                                 display: "inline-block",
-                                backgroundColor:
-                                    theme.palette.background.default,
-                                textAlign: "center",
-                                cursor: "pointer",
                             }}
                         />
                     </Grid>

--- a/src/features/RecipeEdit/components/TextractQueueBrowser.tsx
+++ b/src/features/RecipeEdit/components/TextractQueueBrowser.tsx
@@ -26,13 +26,7 @@ const useStyles = makeStyles((theme) => ({
         position: "relative",
     },
     dropZone: {
-        display: "block",
-        height: "100%",
-        width: "100%",
-        textAlign: "center",
-        paddingTop: "40px",
-        backgroundColor: theme.palette.background.default,
-        cursor: "pointer",
+        padding: "20px 0",
     },
     closeButton: {
         position: "absolute",

--- a/src/features/RecipeLibrary/components/ItemImage.tsx
+++ b/src/features/RecipeLibrary/components/ItemImage.tsx
@@ -1,20 +1,21 @@
-import { CardMedia, useTheme } from "@mui/material";
+import { CardMedia, SxProps, useTheme } from "@mui/material";
 import React from "react";
 import { CommonProps } from "@mui/material/OverridableComponent";
 import { Maybe } from "graphql/jsutils/Maybe";
+import { Theme } from "@mui/material/styles";
 
 interface Props extends CommonProps {
-    url: string;
+    image: string;
     focus?: Maybe<number[]>;
-    title: string;
-    style?: object;
+    alt: string;
+    sx?: SxProps<Theme>;
 }
 
 const ItemImage: React.FC<Props> = ({
-    url,
+    image,
     focus,
-    title,
-    style = {},
+    alt,
+    sx = {},
     ...props
 }) => {
     const x = focus ? focus[0] * 100 : 50;
@@ -23,11 +24,11 @@ const ItemImage: React.FC<Props> = ({
 
     return (
         <CardMedia
-            image={url}
-            title={title}
+            image={image}
+            title={alt}
             {...props}
-            style={{
-                ...style,
+            sx={{
+                ...sx,
                 backgroundColor: theme.palette.background.paper,
                 backgroundPosition: `${x == null ? 50 : x}% ${
                     y == null ? 50 : y

--- a/src/features/RecipeLibrary/components/ItemImageUpload.tsx
+++ b/src/features/RecipeLibrary/components/ItemImageUpload.tsx
@@ -22,18 +22,17 @@ mutation setRecipePhoto($id: ID!, $photo: Upload!) {
 const useStyles = makeStyles({
     root: {
         display: "block",
-        height: 140,
-        textAlign: "center",
-        paddingTop: "30px",
+        padding: "25px 0",
     },
 });
 
 interface Props {
     recipeId: BfsId;
     disabled: boolean;
+    notOnPaper?: boolean;
 }
 
-const ItemImageUpload: React.FC<Props> = ({ recipeId, disabled }) => {
+const ItemImageUpload: React.FC<Props> = ({ recipeId, ...props }) => {
     const classes = useStyles();
     const [setRecipePhoto] = useMutation(SET_RECIPE_PHOTO);
     const handlePhoto = async (photo) => {
@@ -50,9 +49,9 @@ const ItemImageUpload: React.FC<Props> = ({ recipeId, disabled }) => {
     };
     return (
         <ImageDropZone
-            disabled={disabled}
             className={classes.root}
             onImage={handlePhoto}
+            {...props}
         />
     );
 };

--- a/src/features/RecipeLibrary/components/RecipeCard.tsx
+++ b/src/features/RecipeLibrary/components/RecipeCard.tsx
@@ -95,18 +95,22 @@ const RecipeCard: React.FC<Props> = ({ recipe, mine, indicateMine, me }) => {
             }}
         >
             <>
-                {recipe.photo ? (
-                    <Link to={`/library/recipe/${recipe.id}`}>
+                <Link to={`/library/recipe/${recipe.id}`}>
+                    {recipe.photo ? (
                         <ItemImage
                             className={classes.photo}
                             url={recipe.photo.url}
                             focus={recipe.photo.focus}
                             title={recipe.name}
                         />
-                    </Link>
-                ) : (
-                    <ItemImageUpload recipeId={recipe.id} disabled={!mine} />
-                )}
+                    ) : (
+                        <ItemImageUpload
+                            recipeId={recipe.id}
+                            disabled={!mine}
+                            notOnPaper
+                        />
+                    )}
+                </Link>
                 <CardContent style={{ flexGrow: 2 }}>
                     <Grid container alignItems={"start"} wrap={"nowrap"}>
                         <Grid item>

--- a/src/features/RecipeLibrary/components/RecipeCard.tsx
+++ b/src/features/RecipeLibrary/components/RecipeCard.tsx
@@ -99,9 +99,9 @@ const RecipeCard: React.FC<Props> = ({ recipe, mine, indicateMine, me }) => {
                     {recipe.photo ? (
                         <ItemImage
                             className={classes.photo}
-                            url={recipe.photo.url}
+                            image={recipe.photo.url}
                             focus={recipe.photo.focus}
-                            title={recipe.name}
+                            alt={recipe.name}
                         />
                     ) : (
                         <ItemImageUpload

--- a/src/features/RecipeLibrary/components/SearchRecipes.tsx
+++ b/src/features/RecipeLibrary/components/SearchRecipes.tsx
@@ -44,7 +44,11 @@ export const SearchRecipes: React.FC<SearchRecipesProps> = ({
                 <InputBase
                     value={unsavedFilter}
                     onChange={onSearchChange}
-                    placeholder="Search Recipes"
+                    placeholder={
+                        scope === LibrarySearchScope.Everyone
+                            ? "Search Everyone's Recipes"
+                            : "Search My Recipes"
+                    }
                     style={{ flexGrow: 2 }}
                     onKeyDown={(e) => {
                         if (e.key === "Enter") {

--- a/src/global/elements/typography.elements.ts
+++ b/src/global/elements/typography.elements.ts
@@ -4,6 +4,8 @@ export const SmallHeadline = styled("span")({
     fontFamily: "'Encode Sans', sans-serif",
     fontSize: "1rem",
     fontWeight: "bold",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
     padding: 0,
     margin: 0,
 });

--- a/src/util/ImageDropZone.tsx
+++ b/src/util/ImageDropZone.tsx
@@ -8,25 +8,29 @@ import buildSequence from "./buildSequence";
 
 const { next } = buildSequence();
 
-const useStyles = makeStyles(
-    ({ maxWidth, maxHeight }: { maxWidth: any; maxHeight: any }) => ({
-        label: {
-            cursor: "pointer",
-        },
-        preview: {
-            maxWidth: maxWidth || "400px",
-            maxHeight: maxHeight || "200px",
-        },
-        icon: {
-            margin: "30px 40px",
-        },
-        input: {
-            opacity: 0,
-            height: 0,
-            width: 0,
-        },
+const useStyles = makeStyles((theme) => ({
+    label: ({ notOnPaper }: StyleProps) => ({
+        textAlign: "center",
+        backgroundColor: notOnPaper
+            ? theme.palette.neutral.main
+            : theme.palette.background.default,
     }),
-);
+    active: {
+        cursor: "pointer",
+    },
+    preview: ({ maxWidth, maxHeight }: StyleProps) => ({
+        maxWidth: maxWidth || "400px",
+        maxHeight: maxHeight || "200px",
+    }),
+    icon: {
+        margin: "30px 40px",
+    },
+    input: {
+        opacity: 0,
+        height: 0,
+        width: 0,
+    },
+}));
 
 type ImageDropZoneProps = {
     onImage(f: File): void;
@@ -36,7 +40,13 @@ type ImageDropZoneProps = {
     className?: string;
     disabled?: boolean;
     style?: any;
+    notOnPaper?: boolean;
 };
+
+type StyleProps = Pick<
+    ImageDropZoneProps,
+    "maxWidth" | "maxHeight" | "notOnPaper"
+>;
 
 const ImageDropZone: React.FC<ImageDropZoneProps> = ({
     disabled = undefined,
@@ -45,15 +55,16 @@ const ImageDropZone: React.FC<ImageDropZoneProps> = ({
     maxWidth = undefined,
     maxHeight = undefined,
     className: labelClassName = undefined,
+    notOnPaper,
     ...props
 }) => {
-    const classes = useStyles({ maxWidth, maxHeight });
+    const classes = useStyles({ notOnPaper, maxWidth, maxHeight });
     const [value, setValue] = React.useState([]);
     const inputId = React.useMemo(() => `image-drop-zone-${next()}`, []);
 
     if (disabled) {
         return (
-            <label {...props} className={labelClassName}>
+            <label {...props} className={clsx(labelClassName, classes.label)}>
                 <NoPhotoIcon color="disabled" className={classes.icon} />
             </label>
         );
@@ -89,7 +100,7 @@ const ImageDropZone: React.FC<ImageDropZoneProps> = ({
         <label
             title="Drag and drop an image, or click to select one."
             {...props}
-            className={clsx(labelClassName, classes.label)}
+            className={clsx(labelClassName, classes.label, classes.active)}
             htmlFor={inputId}
             onDrop={handleDrop}
             onDragOver={handleDragOver}


### PR DESCRIPTION
The nanocards on the plan sidebar were jagged if only some had images. And if a card's content was too wide, the image was pushed to zero width. Allocate consistent space for images, truncating content if needed, on the right side of the nanocard. Also support focus locations on the images.