### PR TITLE
Recommendations in Library

### DIFF
--- a/src/data/hooks/fragments.ts
+++ b/src/data/hooks/fragments.ts
@@ -56,3 +56,23 @@ fragment librarySearchResult on RecipeConnection {
   }
 }
 `);
+
+export const RECIPE_CARD_FRAGMENT = gql(`
+    fragment recipeCard on Recipe {
+      calories
+      externalUrl
+      favorite
+      id
+      labels
+      name
+      owner {
+        id
+      }
+      photo {
+        url
+        focus
+      }
+      totalTime
+      yield
+    }
+`);

--- a/src/data/hooks/fragments.ts
+++ b/src/data/hooks/fragments.ts
@@ -56,23 +56,3 @@ fragment librarySearchResult on RecipeConnection {
   }
 }
 `);
-
-export const RECIPE_CARD_FRAGMENT = gql(`
-    fragment recipeCard on Recipe {
-      calories
-      externalUrl
-      favorite
-      id
-      labels
-      name
-      owner {
-        id
-      }
-      photo {
-        url
-        focus
-      }
-      totalTime
-      yield
-    }
-`);

--- a/src/data/hooks/useAdaptingQuery.ts
+++ b/src/data/hooks/useAdaptingQuery.ts
@@ -1,5 +1,6 @@
 import {
     ApolloQueryResult,
+    FetchMoreQueryOptions,
     OperationVariables,
     QueryResult,
     TypedDocumentNode,
@@ -48,9 +49,19 @@ export default function useAdaptingQuery<
         [resultAdapter, raw],
     );
 
+    const fetchMore = useCallback(
+        (fetchMoreOptions: FetchMoreQueryOptions<TVariables>) =>
+            raw.fetchMore(fetchMoreOptions).then((result) => ({
+                ...result,
+                data: resultAdapter(result.data, result),
+            })),
+        [resultAdapter, raw],
+    );
+
     return {
         ...raw,
         data,
         refetch,
+        fetchMore,
     };
 }

--- a/src/data/hooks/useAdaptingQuery.ts
+++ b/src/data/hooks/useAdaptingQuery.ts
@@ -41,7 +41,7 @@ export default function useAdaptingQuery<
     }, [resultAdapter, raw]);
 
     const refetch = useCallback(
-        (variables: Partial<TVariables> | undefined) =>
+        (variables?: Partial<TVariables> | undefined) =>
             raw.refetch(variables).then((refetched) => ({
                 ...refetched,
                 data: resultAdapter(refetched.data, refetched),

--- a/src/data/hooks/useGetFullRecipe.ts
+++ b/src/data/hooks/useGetFullRecipe.ts
@@ -1,12 +1,6 @@
 import { useMemo } from "react";
-import {
-    FullRecipe,
-    IngredientRef,
-    Recipe,
-    Subrecipe,
-} from "@/global/types/types";
+import { IngredientRef, Recipe, Subrecipe } from "@/global/types/types";
 import { useProfileId } from "@/providers/Profile";
-import { UseQueryResult } from "@/data/types";
 import { gql } from "@/__generated__";
 import { GetRecipeWithEverythingQuery } from "@/__generated__/graphql";
 import useAdaptingQuery from "./useAdaptingQuery";

--- a/src/data/hooks/useGetFullRecipe.ts
+++ b/src/data/hooks/useGetFullRecipe.ts
@@ -120,9 +120,7 @@ function adapter(
     };
 }
 
-export const useGetFullRecipe = (
-    id: string,
-): UseQueryResult<FullRecipe | null, { id: string }> => {
+export const useGetFullRecipe = (id: string) => {
     const myId = useProfileId();
     const boundAdapter = useMemo(() => adapter.bind(undefined, myId), [myId]);
     return useAdaptingQuery(GET_FULL_RECIPE_QUERY, boundAdapter, {

--- a/src/data/hooks/useGetRecipe.ts
+++ b/src/data/hooks/useGetRecipe.ts
@@ -5,6 +5,7 @@ import { BfsId } from "@/global/types/identity";
 import { GetRecipeQuery } from "@/__generated__/graphql";
 import useAdaptingQuery from "./useAdaptingQuery";
 import objectWithType from "@/data/utils/objectWithType";
+import { QueryResult } from "@apollo/client";
 
 const GET_RECIPE_QUERY = gql(`
 query getRecipe($id: ID!) {
@@ -58,9 +59,7 @@ function adapter(data: GetRecipeQuery | undefined) {
     return recipe;
 }
 
-export const useGetRecipe = (
-    id: string,
-): UseQueryResult<Recipe, { id: string }> => {
+export const useGetRecipe = (id: string) => {
     return useAdaptingQuery(GET_RECIPE_QUERY, adapter, {
         variables: { id: id },
     });

--- a/src/data/hooks/useGetRecipe.ts
+++ b/src/data/hooks/useGetRecipe.ts
@@ -1,11 +1,9 @@
 import { gql } from "@/__generated__";
-import { UseQueryResult } from "@/data/types";
 import { IngredientRef, Recipe } from "@/global/types/types";
 import { BfsId } from "@/global/types/identity";
 import { GetRecipeQuery } from "@/__generated__/graphql";
 import useAdaptingQuery from "./useAdaptingQuery";
 import objectWithType from "@/data/utils/objectWithType";
-import { QueryResult } from "@apollo/client";
 
 const GET_RECIPE_QUERY = gql(`
 query getRecipe($id: ID!) {

--- a/src/data/hooks/usePantryItemSearch.ts
+++ b/src/data/hooks/usePantryItemSearch.ts
@@ -1,5 +1,5 @@
 import { gql } from "@/__generated__";
-import { Results, UseQueryResult } from "@/data/types";
+import { Results } from "@/data/types";
 import {
     PantryItemConnectionEdge,
     PantryItemsQuery,

--- a/src/data/hooks/usePantryItemSearch.ts
+++ b/src/data/hooks/usePantryItemSearch.ts
@@ -1,5 +1,5 @@
 import { gql } from "@/__generated__";
-import { UseQueryResult } from "@/data/types";
+import { Results, UseQueryResult } from "@/data/types";
 import {
     PageInfo,
     PantryItemConnectionEdge,
@@ -43,11 +43,6 @@ export type Result = Pick<
     firstUse: Date;
 };
 
-type Results = {
-    results: Result[];
-    pageInfo: Pick<PageInfo, "hasNextPage">;
-} | null;
-
 export interface Variables {
     query?: string;
     page?: number;
@@ -56,7 +51,7 @@ export interface Variables {
     sortDir?: SortDir;
 }
 
-function adapter(rawData: PantryItemsQuery | undefined): Results {
+function adapter(rawData: PantryItemsQuery | undefined): Results<Result> {
     if (!rawData?.pantry?.search) {
         return null;
     }
@@ -77,7 +72,7 @@ export const usePantryItemSearch = ({
     pageSize = 25,
     sortBy = "name",
     sortDir = SortDir.Asc,
-}: Variables): UseQueryResult<Results, Variables> => {
+}: Variables): UseQueryResult<Results<Result>, Variables> => {
     // DataGrid uses a numeric page model, while the GraphQL API uses cursors,
     // in the style of Relay. However! For the moment those cursors are merely
     // encoded numeric offsets, so do an end-run around tracking cursors in the

--- a/src/data/hooks/usePantryItemSearch.ts
+++ b/src/data/hooks/usePantryItemSearch.ts
@@ -1,7 +1,6 @@
 import { gql } from "@/__generated__";
 import { Results, UseQueryResult } from "@/data/types";
 import {
-    PageInfo,
     PantryItemConnectionEdge,
     PantryItemsQuery,
     SortDir,
@@ -72,7 +71,7 @@ export const usePantryItemSearch = ({
     pageSize = 25,
     sortBy = "name",
     sortDir = SortDir.Asc,
-}: Variables): UseQueryResult<Results<Result>, Variables> => {
+}: Variables) => {
     // DataGrid uses a numeric page model, while the GraphQL API uses cursors,
     // in the style of Relay. However! For the moment those cursors are merely
     // encoded numeric offsets, so do an end-run around tracking cursors in the

--- a/src/data/hooks/usePantryItemUses.ts
+++ b/src/data/hooks/usePantryItemUses.ts
@@ -1,5 +1,4 @@
 import { gql } from "@/__generated__";
-import { UseQueryResult } from "@/data/types";
 import {
     IngredientRef,
     PantryItemUsesQuery,

--- a/src/data/hooks/usePantryItemUses.ts
+++ b/src/data/hooks/usePantryItemUses.ts
@@ -52,9 +52,7 @@ function adapter(rawData: PantryItemUsesQuery | undefined): Results {
     }));
 }
 
-export const usePantryItemUses = (
-    id: string,
-): UseQueryResult<Results, Variables> => {
+export const usePantryItemUses = (id: string) => {
     return useAdaptingQuery(PANTRY_ITEMS_USES, adapter, {
         fetchPolicy: "cache-and-network",
         variables: { id },

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -10,7 +10,7 @@ export type UseQueryResult<T, V extends OperationVariables> = {
     error?: ApolloError;
     data: T | null;
     refetch: ObservableQueryFields<T, V>["refetch"];
-    fetchMore: ObservableQueryFields<T, V>["fetchMore"];
+    fetchMore?: ObservableQueryFields<T, V>["fetchMore"];
 };
 
 export type Results<T> = {

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -10,9 +10,10 @@ export type UseQueryResult<T, V extends OperationVariables> = {
     error?: ApolloError;
     data: T | null;
     refetch: ObservableQueryFields<T, V>["refetch"];
+    fetchMore: ObservableQueryFields<T, V>["fetchMore"];
 };
 
 export type Results<T> = {
     results: T[];
-    pageInfo: Pick<PageInfo, "hasNextPage">;
+    pageInfo: Pick<PageInfo, "hasNextPage" | "endCursor">;
 } | null;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -15,5 +15,5 @@ export type UseQueryResult<T, V extends OperationVariables> = {
 
 export type Results<T> = {
     results: T[];
-    pageInfo: Pick<PageInfo, "hasNextPage" | "endCursor">;
+    pageInfo: Partial<PageInfo>;
 } | null;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -3,6 +3,7 @@ import {
     ObservableQueryFields,
     OperationVariables,
 } from "@apollo/client";
+import { PageInfo } from "@/__generated__/graphql";
 
 export type UseQueryResult<T, V extends OperationVariables> = {
     loading: boolean;
@@ -10,3 +11,8 @@ export type UseQueryResult<T, V extends OperationVariables> = {
     data: T | null;
     refetch: ObservableQueryFields<T, V>["refetch"];
 };
+
+export type Results<T> = {
+    results: T[];
+    pageInfo: Pick<PageInfo, "hasNextPage">;
+} | null;

--- a/src/features/LibrarySearch/LibrarySearchController.tsx
+++ b/src/features/LibrarySearch/LibrarySearchController.tsx
@@ -4,14 +4,14 @@ import { SearchInput } from "@/features/LibrarySearch/components/SearchInput";
 import { DisplayOptions, SearchScope } from "@/features/LibrarySearch/types";
 import { useSearchLibrary } from "@/features/RecipeLibrary/hooks/useSearchLibrary";
 import LoadingIndicator from "@/views/common/LoadingIndicator";
-import { RecipeListDisplay } from "@/features/LibrarySearch/components/RecipeListDisplay";
-import { RecipeGridDisplay } from "@/features/LibrarySearch/components/RecipeGridDisplay";
+import { RecipeListDisplay } from "@/views/recipeCollections/RecipeListDisplay";
 import { useProfile } from "@/providers/Profile";
 import { ScalingProvider } from "@/util/ScalingContext";
-import { SearchResults } from "@/features/LibrarySearch/components/RecipeDisplay.elements";
 import { LibrarySearchScope } from "@/__generated__/graphql";
 import { Grid } from "@mui/material";
 import { MessagePaper } from "@/features/RecipeLibrary/components/MessagePaper";
+import { RecipeGrid } from "@/views/recipeCollections/RecipeGrid";
+import { SearchResults } from "@/views/recipeCollections/RecipeCollection.elements";
 
 type LibrarySearchControllerProps = {
     display?: DisplayOptions;
@@ -65,10 +65,11 @@ export const LibrarySearchController: React.FC<
                                     markAsMine={markAsMine}
                                 />
                             ) : (
-                                <RecipeGridDisplay
+                                <RecipeGrid
                                     recipes={recipes}
                                     me={me}
                                     markAsMine={markAsMine}
+                                    cardType="standard"
                                 />
                             )}
                         </>

--- a/src/features/RecipeLibrary/LibraryController.tsx
+++ b/src/features/RecipeLibrary/LibraryController.tsx
@@ -6,17 +6,13 @@ import { useHistory } from "react-router-dom";
 import { LibrarySearchScope } from "@/__generated__/graphql";
 import { useSearchLibrary } from "@/features/RecipeLibrary/hooks/useSearchLibrary";
 import { ScalingProvider } from "@/util/ScalingContext";
-import * as React from "react";
 import LoadingIndicator from "@/views/common/LoadingIndicator";
 import { SearchRecipes } from "@/features/RecipeLibrary/components/SearchRecipes";
-import { Typography, useScrollTrigger } from "@mui/material";
+import { useScrollTrigger } from "@mui/material";
 import { useIsMobile } from "@/providers/IsMobile";
 import { useRecommendedRecipes } from "@/features/RecipeLibrary/hooks/useRecommendedRecipes";
 import { RecipeGrid } from "@/views/recipeCollections/RecipeGrid";
-import {
-    SectionHeadline,
-    SmallHeadline,
-} from "@/global/elements/typography.elements";
+import { SectionHeadline } from "@/global/elements/typography.elements";
 import useIsDevMode from "@/data/useIsDevMode";
 import Button from "@mui/material/Button";
 
@@ -142,7 +138,7 @@ export const LibraryController = () => {
                         />
                         <Button
                             variant="text"
-                            onClick={(e) =>
+                            onClick={() =>
                                 fetchMoreRecommended({
                                     variables: {
                                         after: recommended?.pageInfo?.endCursor,

--- a/src/features/RecipeLibrary/LibraryController.tsx
+++ b/src/features/RecipeLibrary/LibraryController.tsx
@@ -25,6 +25,7 @@ import Button from "@mui/material/Button";
  */
 export const LibraryController = () => {
     const devMode = useIsDevMode();
+    const isMobile = useIsMobile();
     const me = useProfile();
     const history = useHistory();
     const params = history.location.search
@@ -43,8 +44,6 @@ export const LibraryController = () => {
         threshold: 15,
     });
 
-    const isMobile = useIsMobile();
-
     const {
         data: recipes,
         loading,
@@ -58,7 +57,7 @@ export const LibraryController = () => {
     });
 
     const { data: recommended, fetchMore: fetchMoreRecommended } =
-        useRecommendedRecipes(9);
+        useRecommendedRecipes(isMobile ? 3 : 9);
 
     function handleSearchChange(e) {
         setUnsavedQuery(e.target.value);
@@ -136,18 +135,21 @@ export const LibraryController = () => {
                             markAsMine={markAsMine}
                             cardType="nano"
                         />
-                        <Button
-                            variant="text"
-                            onClick={() =>
-                                fetchMoreRecommended({
-                                    variables: {
-                                        after: recommended?.pageInfo?.endCursor,
-                                    },
-                                })
-                            }
-                        >
-                            Show More
-                        </Button>
+                        {recommended?.pageInfo?.hasNextPage && (
+                            <Button
+                                variant="text"
+                                onClick={() =>
+                                    fetchMoreRecommended({
+                                        variables: {
+                                            after: recommended?.pageInfo
+                                                ?.endCursor,
+                                        },
+                                    })
+                                }
+                            >
+                                Show More
+                            </Button>
+                        )}
                         <SectionHeadline>All Recipes</SectionHeadline>
                     </>
                 )}

--- a/src/features/RecipeLibrary/LibraryController.tsx
+++ b/src/features/RecipeLibrary/LibraryController.tsx
@@ -6,9 +6,20 @@ import { useHistory } from "react-router-dom";
 import { LibrarySearchScope } from "@/__generated__/graphql";
 import { useSearchLibrary } from "@/features/RecipeLibrary/hooks/useSearchLibrary";
 import { ScalingProvider } from "@/util/ScalingContext";
+import * as React from "react";
+import LoadingIndicator from "@/views/common/LoadingIndicator";
+import { SearchRecipes } from "@/features/RecipeLibrary/components/SearchRecipes";
+import { Typography, useScrollTrigger } from "@mui/material";
+import { useIsMobile } from "@/providers/IsMobile";
+import { useRecommendedRecipes } from "@/features/RecipeLibrary/hooks/useRecommendedRecipes";
+import { RecipeGrid } from "@/views/recipeCollections/RecipeGrid";
+import {
+    SectionHeadline,
+    SmallHeadline,
+} from "@/global/elements/typography.elements";
 
 /**
- * TODO
+ * TODO: Issue-218
  * Note that this Library now has duplicated "search" functionality
  * with the LibrarySearch. This needs to get sorted eventually,
  * by pulling in that Library Search and composing it into the
@@ -21,11 +32,20 @@ export const LibraryController = () => {
         ? qs.parse(history.location.search.substring(1))
         : {};
     const [query, setQuery] = useState(params.q ? "" + params.q : "");
+    const [unsavedQuery, setUnsavedQuery] = useState(query);
     const [scope, setScope] = useState(
         params.s === LibrarySearchScope.Everyone
             ? LibrarySearchScope.Everyone
             : LibrarySearchScope.Mine,
     );
+
+    const isSearchFloating = useScrollTrigger({
+        disableHysteresis: true,
+        threshold: 15,
+    });
+
+    const isMobile = useIsMobile();
+
     const {
         data: recipes,
         loading,
@@ -37,6 +57,32 @@ export const LibraryController = () => {
         scope,
         query,
     });
+
+    const { data: recommended } = useRecommendedRecipes(9);
+
+    function handleSearchChange(e) {
+        setUnsavedQuery(e.target.value);
+    }
+
+    function handleClear(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        setUnsavedQuery("");
+        handleSearch("", scope);
+    }
+
+    function doSearch(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        handleSearch(unsavedQuery, scope);
+    }
+
+    function toggleScope(e) {
+        const scope = e.target.checked
+            ? LibrarySearchScope.Everyone
+            : LibrarySearchScope.Mine;
+        handleSearch(query, scope);
+    }
 
     function handleSearch(newQuery, newScope) {
         if (query === newQuery && scope === newScope) {
@@ -60,18 +106,49 @@ export const LibraryController = () => {
         });
     }
 
+    const markAsMine = scope === LibrarySearchScope.Everyone;
+
+    if (loading) {
+        return <LoadingIndicator />;
+    }
+
     return (
-        <ScalingProvider>
-            <RecipesList
-                me={me}
-                onSearch={handleSearch}
+        <>
+            <SearchRecipes
+                isSearchFloating={isSearchFloating}
+                isMobile={isMobile}
+                onClear={handleClear}
+                unsavedFilter={unsavedQuery}
+                onSearchChange={handleSearchChange}
+                onSearch={doSearch}
                 scope={scope}
-                filter={query}
-                recipes={recipes}
-                isLoading={loading}
-                isComplete={isComplete}
-                onNeedMore={handleNeedMore}
+                toggleScope={toggleScope}
             />
-        </ScalingProvider>
+            <ScalingProvider>
+                {query === "" && recommended && (
+                    <>
+                        <SectionHeadline>Recommended</SectionHeadline>
+                        <RecipeGrid
+                            recipes={recommended.results}
+                            me={me}
+                            markAsMine={markAsMine}
+                            cardType="nano"
+                        />
+                        <SectionHeadline>All Recipes</SectionHeadline>
+                    </>
+                )}
+                <RecipesList
+                    me={me}
+                    isMobile={isMobile}
+                    onSearch={handleSearch}
+                    scope={scope}
+                    filter={query}
+                    recipes={recipes}
+                    isLoading={loading}
+                    isComplete={isComplete}
+                    onNeedMore={handleNeedMore}
+                />
+            </ScalingProvider>
+        </>
     );
 };

--- a/src/features/RecipeLibrary/LibraryController.tsx
+++ b/src/features/RecipeLibrary/LibraryController.tsx
@@ -17,6 +17,8 @@ import {
     SectionHeadline,
     SmallHeadline,
 } from "@/global/elements/typography.elements";
+import useIsDevMode from "@/data/useIsDevMode";
+import Button from "@mui/material/Button";
 
 /**
  * TODO: Issue-218
@@ -26,6 +28,7 @@ import {
  * Library here.
  */
 export const LibraryController = () => {
+    const devMode = useIsDevMode();
     const me = useProfile();
     const history = useHistory();
     const params = history.location.search
@@ -58,7 +61,8 @@ export const LibraryController = () => {
         query,
     });
 
-    const { data: recommended } = useRecommendedRecipes(9);
+    const { data: recommended, fetchMore: fetchMoreRecommended } =
+        useRecommendedRecipes(9);
 
     function handleSearchChange(e) {
         setUnsavedQuery(e.target.value);
@@ -108,6 +112,8 @@ export const LibraryController = () => {
 
     const markAsMine = scope === LibrarySearchScope.Everyone;
 
+    const showRecommendations = devMode && query === "" && recommended;
+
     if (loading) {
         return <LoadingIndicator />;
     }
@@ -125,7 +131,7 @@ export const LibraryController = () => {
                 toggleScope={toggleScope}
             />
             <ScalingProvider>
-                {query === "" && recommended && (
+                {showRecommendations && (
                     <>
                         <SectionHeadline>Recommended</SectionHeadline>
                         <RecipeGrid
@@ -134,6 +140,18 @@ export const LibraryController = () => {
                             markAsMine={markAsMine}
                             cardType="nano"
                         />
+                        <Button
+                            variant="text"
+                            onClick={(e) =>
+                                fetchMoreRecommended({
+                                    variables: {
+                                        after: recommended?.pageInfo?.endCursor,
+                                    },
+                                })
+                            }
+                        >
+                            Show More
+                        </Button>
                         <SectionHeadline>All Recipes</SectionHeadline>
                     </>
                 )}

--- a/src/features/RecipeLibrary/components/RecipeCard.tsx
+++ b/src/features/RecipeLibrary/components/RecipeCard.tsx
@@ -22,10 +22,9 @@ import RecipeInfo from "@/views/common/RecipeInfo";
 import Source from "@/views/common/Source";
 import User from "@/views/user/User";
 import FavoriteIndicator from "../../Favorites/components/Indicator";
-import { Photo, User as UserType } from "@/__generated__/graphql";
 import LabelItem from "@/global/components/LabelItem";
 import { TaskBar, TaskBarButton } from "@/global/elements/taskbar.elements";
-import { RecipeCard, RecipeType } from "@/features/RecipeLibrary/types";
+import { RecipeCard } from "@/features/RecipeLibrary/types";
 
 const useStyles = makeStyles({
     photo: {

--- a/src/features/RecipeLibrary/components/RecipeCard.tsx
+++ b/src/features/RecipeLibrary/components/RecipeCard.tsx
@@ -25,6 +25,7 @@ import FavoriteIndicator from "../../Favorites/components/Indicator";
 import { Photo, User as UserType } from "@/__generated__/graphql";
 import LabelItem from "@/global/components/LabelItem";
 import { TaskBar, TaskBarButton } from "@/global/elements/taskbar.elements";
+import { RecipeCard, RecipeType } from "@/features/RecipeLibrary/types";
 
 const useStyles = makeStyles({
     photo: {
@@ -36,22 +37,8 @@ const useStyles = makeStyles({
     },
 });
 
-export interface RecipeType {
-    id: string;
-    calories?: number | null;
-    directions?: string;
-    externalUrl?: string | null;
-    favorite: boolean;
-    labels?: string[] | null;
-    name: string;
-    owner: UserType;
-    photo?: Photo | null;
-    totalTime?: number | null;
-    yield?: number | null;
-}
-
 interface Props {
-    recipe: RecipeType;
+    recipe: RecipeCard;
     mine: boolean;
     indicateMine: boolean;
     me: any; // todo
@@ -61,10 +48,10 @@ const RecipeCard: React.FC<Props> = ({ recipe, mine, indicateMine, me }) => {
     const owner = useFluxStore(
         () => {
             if (mine) return indicateMine ? me : null;
-            return FriendStore.getFriendRlo(recipe.owner.id).data;
+            return FriendStore.getFriendRlo(recipe.ownerId).data;
         },
         [FriendStore],
-        [mine, indicateMine, me, recipe.owner.id],
+        [mine, indicateMine, me, recipe.ownerId],
     );
     const classes = useStyles();
     const [raised, setRaised] = React.useState(false);
@@ -76,7 +63,8 @@ const RecipeCard: React.FC<Props> = ({ recipe, mine, indicateMine, me }) => {
     const handleClick = (planId: number, scale?: number) => {
         Dispatcher.dispatch({
             type: RecipeActions.SEND_TO_PLAN,
-            recipeId: parseInt(recipe.id),
+            recipeId:
+                typeof recipe.id === "string" ? parseInt(recipe.id) : recipe.id,
             planId,
             scale: scale ? scale : 1,
         });
@@ -99,8 +87,8 @@ const RecipeCard: React.FC<Props> = ({ recipe, mine, indicateMine, me }) => {
                     {recipe.photo ? (
                         <ItemImage
                             className={classes.photo}
-                            image={recipe.photo.url}
-                            focus={recipe.photo.focus}
+                            image={recipe.photo}
+                            focus={recipe.photoFocus}
                             alt={recipe.name}
                         />
                     ) : (
@@ -145,10 +133,10 @@ const RecipeCard: React.FC<Props> = ({ recipe, mine, indicateMine, me }) => {
                             text={<Source url={recipe.externalUrl} />}
                         />
                     )}
-                    {recipe.yield && (
+                    {recipe.recipeYield && (
                         <RecipeInfo
                             label="Yield"
-                            text={`${recipe.yield} servings`}
+                            text={`${recipe.recipeYield} servings`}
                         />
                     )}
                     {recipe.totalTime && (

--- a/src/features/RecipeLibrary/components/RecipesList.tsx
+++ b/src/features/RecipeLibrary/components/RecipesList.tsx
@@ -1,7 +1,6 @@
 import { AddRecipeIcon } from "@/views/common/icons";
 import { Container as Content, Grid, useScrollTrigger } from "@mui/material";
 import RecipeCard from "@/features/RecipeLibrary/components/RecipeCard";
-import { useIsMobile } from "@/providers/IsMobile";
 import React, { useState } from "react";
 import history from "@/util/history";
 import FoodingerFab from "@/views/common/FoodingerFab";
@@ -9,8 +8,6 @@ import LazyInfinite from "@/views/common/LazyInfinite";
 import LoadingIndicator from "@/views/common/LoadingIndicator";
 import { LibrarySearchScope } from "@/__generated__/graphql";
 import { MessagePaper } from "@/features/RecipeLibrary/components/MessagePaper";
-import { SearchRecipes } from "@/features/RecipeLibrary/components/SearchRecipes";
-import { RecipeType } from "@/features/RecipeLibrary/types";
 
 interface RecipesListProps {
     me: any; // todo
@@ -18,11 +15,12 @@ interface RecipesListProps {
     scope?: LibrarySearchScope;
     isLoading: boolean;
     isComplete: boolean;
-    recipes?: RecipeType[];
+    recipes?: RecipeCard[];
 
     onSearch(filter: string, scope: LibrarySearchScope): void;
 
     onNeedMore(): void;
+    isMobile: boolean;
 }
 
 export const RecipesList: React.FC<RecipesListProps> = ({
@@ -32,40 +30,9 @@ export const RecipesList: React.FC<RecipesListProps> = ({
     recipes,
     isLoading,
     isComplete,
-    onSearch,
     onNeedMore,
+    isMobile,
 }) => {
-    const isSearchFloating = useScrollTrigger({
-        disableHysteresis: true,
-        threshold: 15,
-    });
-    const isMobile = useIsMobile();
-    const [unsavedFilter, setUnsavedFilter] = useState(filter);
-
-    function handleSearchChange(e) {
-        setUnsavedFilter(e.target.value);
-    }
-
-    function handleClear(e) {
-        e.preventDefault();
-        e.stopPropagation();
-        setUnsavedFilter("");
-        onSearch("", scope);
-    }
-
-    function handleSearch(e) {
-        e.preventDefault();
-        e.stopPropagation();
-        onSearch(unsavedFilter, scope);
-    }
-
-    function toggleScope(e) {
-        const scope = e.target.checked
-            ? LibrarySearchScope.Everyone
-            : LibrarySearchScope.Mine;
-        onSearch(filter, scope);
-    }
-
     let body;
     if (recipes) {
         if (recipes.length > 0) {
@@ -91,7 +58,7 @@ export const RecipesList: React.FC<RecipesListProps> = ({
                                     indicateMine={
                                         scope === LibrarySearchScope.Everyone
                                     }
-                                    mine={recipe.owner.id === "" + me.id}
+                                    mine={recipe.ownerId === "" + me.id}
                                 />
                             </Grid>
                         ))}
@@ -123,24 +90,7 @@ export const RecipesList: React.FC<RecipesListProps> = ({
                 />
             );
         }
-    } else {
-        body = <LoadingIndicator />;
     }
-    body = (
-        <>
-            <SearchRecipes
-                isSearchFloating={isSearchFloating}
-                isMobile={isMobile}
-                onClear={handleClear}
-                unsavedFilter={unsavedFilter}
-                onSearchChange={handleSearchChange}
-                onSearch={handleSearch}
-                scope={scope}
-                toggleScope={toggleScope}
-            />
-            {body}
-        </>
-    );
 
     return (
         <Content disableGutters={!isMobile}>

--- a/src/features/RecipeLibrary/components/RecipesList.tsx
+++ b/src/features/RecipeLibrary/components/RecipesList.tsx
@@ -1,7 +1,7 @@
 import { AddRecipeIcon } from "@/views/common/icons";
-import { Container as Content, Grid, useScrollTrigger } from "@mui/material";
+import { Container as Content, Grid } from "@mui/material";
 import RecipeCard from "@/features/RecipeLibrary/components/RecipeCard";
-import React, { useState } from "react";
+import React from "react";
 import history from "@/util/history";
 import FoodingerFab from "@/views/common/FoodingerFab";
 import LazyInfinite from "@/views/common/LazyInfinite";

--- a/src/features/RecipeLibrary/data/queries.ts
+++ b/src/features/RecipeLibrary/data/queries.ts
@@ -14,14 +14,3 @@ export const SEARCH_RECIPES = gql(`
         }
     }
 `);
-
-export const SUGGEST_RECIPES = gql(`
-query recipeSuggestions(
-    $first: NonNegativeInt! = 9
-    $after: Cursor = null) {
-  library {
-    recipes: suggestRecipesToCook(first: $first, after: $after) {
-      ...librarySearchResult
-    }
-  }
-}`);

--- a/src/features/RecipeLibrary/hooks/useRecommendedRecipes.ts
+++ b/src/features/RecipeLibrary/hooks/useRecommendedRecipes.ts
@@ -1,6 +1,6 @@
 import { gql } from "@/__generated__";
 import useAdaptingQuery from "@/data/hooks/useAdaptingQuery";
-import { Results, UseQueryResult } from "@/data/types";
+import { Results } from "@/data/types";
 import { BfsId } from "@/global/types/identity";
 import { RecipeCard } from "@/features/RecipeLibrary/types";
 import { GetRecipeSuggestionsQuery } from "@/__generated__/graphql";

--- a/src/features/RecipeLibrary/hooks/useRecommendedRecipes.ts
+++ b/src/features/RecipeLibrary/hooks/useRecommendedRecipes.ts
@@ -1,45 +1,34 @@
 import { gql } from "@/__generated__";
 import useAdaptingQuery from "@/data/hooks/useAdaptingQuery";
-import {
-    GetRecommendationsQuery,
-    SuggestionRequest,
-} from "@/__generated__/graphql";
 import { Results, UseQueryResult } from "@/data/types";
-import { Recipe } from "@/global/types/types";
 import { BfsId } from "@/global/types/identity";
 import { RecipeCard } from "@/features/RecipeLibrary/types";
+import { GetRecipeSuggestionsQuery } from "@/__generated__/graphql";
 
 const GET_RECOMMENDATIONS_QUERY = gql(`
-query getRecommendations($req: SuggestionRequest) {
+query getRecipeSuggestions(
+    $first: NonNegativeInt! = 9
+    $after: Cursor = null) {
   library {
-    suggestRecipesToCook(req: $req) {
-      pageInfo {
-        hasPreviousPage
-        hasNextPage
-      }
-      edges {
-        cursor
-        node {
-         ...recipeCard
-        }
-      }
+    recipes: suggestRecipesToCook(first: $first, after: $after) {
+      ...librarySearchResult
     }
   }
-}
-`);
+}`);
 
 function adapter(
-    data: GetRecommendationsQuery | undefined,
+    data: GetRecipeSuggestionsQuery | undefined,
 ): Results<RecipeCard> {
-    const result = data?.library?.suggestRecipesToCook || null;
+    const result = data?.library?.recipes || null;
     if (!result) {
         return {
             results: [] as RecipeCard[],
-            pageInfo: { hasNextPage: false },
+            pageInfo: { hasNextPage: false, endCursor: null },
         };
     }
 
     const { edges, pageInfo } = result;
+
     return {
         results: edges.map((it) => {
             const recipe = it.node;
@@ -61,11 +50,9 @@ function adapter(
     };
 }
 
-export const useRecommendedRecipes = (
-    limit: number,
-): UseQueryResult<Results<RecipeCard>, { req: SuggestionRequest }> => {
+export const useRecommendedRecipes = (limit: number) => {
     return useAdaptingQuery(GET_RECOMMENDATIONS_QUERY, adapter, {
         fetchPolicy: "cache-and-network",
-        variables: { req: { first: limit, after: null } },
+        variables: { first: limit, after: null },
     });
 };

--- a/src/features/RecipeLibrary/hooks/useRecommendedRecipes.ts
+++ b/src/features/RecipeLibrary/hooks/useRecommendedRecipes.ts
@@ -1,0 +1,71 @@
+import { gql } from "@/__generated__";
+import useAdaptingQuery from "@/data/hooks/useAdaptingQuery";
+import {
+    GetRecommendationsQuery,
+    SuggestionRequest,
+} from "@/__generated__/graphql";
+import { Results, UseQueryResult } from "@/data/types";
+import { Recipe } from "@/global/types/types";
+import { BfsId } from "@/global/types/identity";
+import { RecipeCard } from "@/features/RecipeLibrary/types";
+
+const GET_RECOMMENDATIONS_QUERY = gql(`
+query getRecommendations($req: SuggestionRequest) {
+  library {
+    suggestRecipesToCook(req: $req) {
+      pageInfo {
+        hasPreviousPage
+        hasNextPage
+      }
+      edges {
+        cursor
+        node {
+         ...recipeCard
+        }
+      }
+    }
+  }
+}
+`);
+
+function adapter(
+    data: GetRecommendationsQuery | undefined,
+): Results<RecipeCard> {
+    const result = data?.library?.suggestRecipesToCook || null;
+    if (!result) {
+        return {
+            results: [] as RecipeCard[],
+            pageInfo: { hasNextPage: false },
+        };
+    }
+
+    const { edges, pageInfo } = result;
+    return {
+        results: edges.map((it) => {
+            const recipe = it.node;
+            return {
+                calories: recipe?.calories,
+                externalUrl: recipe?.externalUrl,
+                favorite: recipe?.favorite,
+                id: recipe?.id as BfsId,
+                labels: recipe?.labels ?? [],
+                name: recipe?.name ?? "",
+                ownerId: recipe?.owner.id,
+                photo: recipe?.photo?.url ?? null,
+                photoFocus: recipe?.photo?.focus ?? [],
+                recipeYield: recipe?.yield,
+                totalTime: recipe?.totalTime,
+            };
+        }),
+        pageInfo,
+    };
+}
+
+export const useRecommendedRecipes = (
+    limit: number,
+): UseQueryResult<Results<RecipeCard>, { req: SuggestionRequest }> => {
+    return useAdaptingQuery(GET_RECOMMENDATIONS_QUERY, adapter, {
+        fetchPolicy: "cache-and-network",
+        variables: { req: { first: limit, after: null } },
+    });
+};

--- a/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
+++ b/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
@@ -21,9 +21,9 @@ export const useSearchLibrary = ({
     query,
 }): UseSearchLibraryQueryResult => {
     const devMode = useIsDevMode();
-    const suggest = !query && scope === LibrarySearchScope.Mine && devMode;
+    // const suggest = !query && scope === LibrarySearchScope.Mine && devMode;
     const { data, error, loading, refetch, fetchMore } = useQuery(
-        suggest ? SUGGEST_RECIPES : SEARCH_RECIPES,
+        SEARCH_RECIPES,
         {
             fetchPolicy: "cache-and-network",
             variables: {

--- a/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
+++ b/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
@@ -43,9 +43,10 @@ export const useSearchLibrary = ({
             externalUrl: it.node.externalUrl || null,
             favorite: it.node.favorite,
             labels: it.node.labels || [],
-            photo: it.node.photo || null,
+            photo: it.node.photo?.url || null,
+            photoFocus: it.node.photo?.focus || null,
             totalTime: it.node.totalTime || null,
-            yield: it.node.yield || null,
+            recipeYield: it.node.yield || null,
         })) || [];
 
     return {

--- a/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
+++ b/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
@@ -20,8 +20,6 @@ export const useSearchLibrary = ({
     scope,
     query,
 }): UseSearchLibraryQueryResult => {
-    const devMode = useIsDevMode();
-    // const suggest = !query && scope === LibrarySearchScope.Mine && devMode;
     const { data, error, loading, refetch, fetchMore } = useQuery(
         SEARCH_RECIPES,
         {

--- a/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
+++ b/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
@@ -1,11 +1,6 @@
-import {
-    SEARCH_RECIPES,
-    SUGGEST_RECIPES,
-} from "@/features/RecipeLibrary/data/queries";
+import { SEARCH_RECIPES } from "@/features/RecipeLibrary/data/queries";
 import { QueryResult, useQuery } from "@apollo/client";
 import type { RecipeCard } from "@/features/RecipeLibrary/types";
-import useIsDevMode from "@/data/useIsDevMode";
-import { LibrarySearchScope } from "@/__generated__/graphql";
 
 interface UseSearchLibraryQueryResult
     extends Pick<

--- a/src/features/RecipeLibrary/types.ts
+++ b/src/features/RecipeLibrary/types.ts
@@ -1,18 +1,10 @@
 import { Photo, User as UserType } from "@/__generated__/graphql";
-import { BfsId } from "@/global/types/identity";
+import { Recipe } from "@/global/types/types";
 
-export interface RecipeCard {
-    id: BfsId;
-    name: string;
-    owner: Partial<UserType>;
-    calories?: number | null;
-    externalUrl?: string | null;
-    favorite: boolean;
-    labels?: string[] | null;
-    photo?: Photo | null;
-    totalTime?: number | null;
-    yield?: number | null;
-}
+export type RecipeCard = Omit<
+    Recipe,
+    "directions" | "ingredients" | "libraryRecipeId"
+>;
 
 export interface RecipeType {
     id: string;

--- a/src/global/elements/typography.elements.ts
+++ b/src/global/elements/typography.elements.ts
@@ -10,6 +10,13 @@ export const SmallHeadline = styled("span")({
     margin: 0,
 });
 
+export const SectionHeadline = styled("h3")(({ theme }) => ({
+    fontFamily: "'Encode Sans', sans-serif",
+    fontSize: "1.2rem",
+    marginBottom: theme.spacing(1),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+}));
+
 export const SmallLabel = styled("span")(({ theme }) => ({
     color: theme.palette.text.primary,
     fontSize: `12px`,

--- a/src/global/elements/typography.elements.ts
+++ b/src/global/elements/typography.elements.ts
@@ -1,4 +1,5 @@
 import { styled } from "@mui/material/styles";
+import { Link } from "react-router-dom";
 
 export const SmallHeadline = styled("span")({
     fontFamily: "'Encode Sans', sans-serif",
@@ -20,4 +21,16 @@ export const SectionHeadline = styled("h3")(({ theme }) => ({
 export const SmallLabel = styled("span")(({ theme }) => ({
     color: theme.palette.text.primary,
     fontSize: `12px`,
+}));
+
+export const LinkTitle = styled(Link)(({ theme }) => ({
+    color: theme.palette.text.primary,
+    fontFamily: "'Encode Sans', sans-serif",
+    fontSize: "1rem",
+    fontWeight: "bold",
+    margin: 0,
+    overflow: "hidden",
+    padding: 0,
+    textOverflow: "ellipsis",
+    textDecoration: "none",
 }));

--- a/src/global/types/types.ts
+++ b/src/global/types/types.ts
@@ -26,6 +26,7 @@ export interface Recipe extends Ingredient {
      */
     libraryRecipeId?: BfsId;
     ownerId?: BfsId;
+    favorite?: boolean;
 }
 
 export interface PantryItem extends Ingredient {

--- a/src/views/recipeCollections/NanoCard.tsx
+++ b/src/views/recipeCollections/NanoCard.tsx
@@ -11,10 +11,7 @@ import {
     NanoRecipeCard,
 } from "@/views/recipeCollections/RecipeCollection.elements";
 import { TaskBar, TaskBarButton } from "@/global/elements/taskbar.elements";
-import {
-    SmallHeadline,
-    SmallLabel,
-} from "@/global/elements/typography.elements";
+import { LinkTitle, SmallLabel } from "@/global/elements/typography.elements";
 import { Link } from "react-router-dom";
 import ItemImage from "@/features/RecipeLibrary/components/ItemImage";
 
@@ -77,7 +74,9 @@ export const NanoCard: React.FC<RecipeListItemProps> = ({ recipe, isMine }) => {
                         </TaskBarButton>
                     )}
                 </TaskBar>
-                <SmallHeadline>{recipe.name}</SmallHeadline>
+                <LinkTitle to={`/library/recipe/${recipe.id}`}>
+                    {recipe.name}
+                </LinkTitle>
                 {labelsToDisplay && (
                     <Box my={0.5}>
                         {labelsToDisplay.map((label, idx) => (

--- a/src/views/recipeCollections/NanoCard.tsx
+++ b/src/views/recipeCollections/NanoCard.tsx
@@ -4,12 +4,12 @@ import { Box } from "@mui/material";
 import Dispatcher from "@/data/dispatcher";
 import RecipeActions from "@/data/RecipeActions";
 import SendToPlan from "@/features/RecipeLibrary/components/SendToPlan";
-import FavoriteIndicator from "../../Favorites/components/Indicator";
-import { RecipeType } from "@/features/RecipeLibrary/types";
+import { RecipeCard } from "@/features/RecipeLibrary/types";
+import FavoriteIndicator from "@/features/Favorites/components/Indicator";
 import {
     NanoCardContent,
     NanoRecipeCard,
-} from "@/features/LibrarySearch/components/RecipeDisplay.elements";
+} from "@/views/recipeCollections/RecipeCollection.elements";
 import { TaskBar, TaskBarButton } from "@/global/elements/taskbar.elements";
 import {
     SmallHeadline,
@@ -19,16 +19,12 @@ import { Link } from "react-router-dom";
 import ItemImage from "@/features/RecipeLibrary/components/ItemImage";
 
 type RecipeListItemProps = {
-    recipe: RecipeType;
-    mine: boolean;
-    markAsMine: boolean;
+    recipe: RecipeCard;
+    isMine: boolean;
 };
 
 // TODO: add owner indicator?
-export const RecipeListItem: React.FC<RecipeListItemProps> = ({
-    recipe,
-    mine,
-}) => {
+export const NanoCard: React.FC<RecipeListItemProps> = ({ recipe, isMine }) => {
     const [raised, setRaised] = React.useState(false);
     const labelsToDisplay =
         recipe.labels &&
@@ -37,7 +33,8 @@ export const RecipeListItem: React.FC<RecipeListItemProps> = ({
     const handleClick = (planId: number, scale?: number) => {
         Dispatcher.dispatch({
             type: RecipeActions.SEND_TO_PLAN,
-            recipeId: parseInt(recipe.id),
+            recipeId:
+                typeof recipe.id === "string" ? parseInt(recipe.id) : recipe.id,
             planId,
             scale: scale ? scale : 1,
         });
@@ -49,16 +46,16 @@ export const RecipeListItem: React.FC<RecipeListItemProps> = ({
             onMouseEnter={() => setRaised(true)}
             onMouseLeave={() => setRaised(false)}
         >
-            {recipe.photo && recipe.photo.url && (
+            {recipe.photo && (
                 <ItemImage
                     sx={{
                         width: "20%",
                         order: 2,
                         overflow: "hidden",
                     }}
-                    image={recipe.photo.url}
+                    image={recipe.photo}
                     alt={recipe.name}
-                    focus={recipe.photo.focus}
+                    focus={recipe.photoFocus}
                 />
             )}
             <NanoCardContent>
@@ -71,7 +68,7 @@ export const RecipeListItem: React.FC<RecipeListItemProps> = ({
                     >
                         <ViewIcon />
                     </TaskBarButton>
-                    {mine && (
+                    {isMine && (
                         <TaskBarButton
                             component={Link}
                             to={`/library/recipe/${recipe.id}/edit`}

--- a/src/views/recipeCollections/RecipeCollection.elements.tsx
+++ b/src/views/recipeCollections/RecipeCollection.elements.tsx
@@ -11,6 +11,8 @@ export const NanoRecipeCard = styled(Card)(({ theme }) => ({
     borderRadius: theme.shape.borderRadius,
     backgroundColor: theme.palette.background.default,
     width: "100%",
+    margin: theme.spacing(1),
+    paddingTop: theme.spacing(1),
 }));
 
 export const NanoCardContent = styled("div")(({ theme }) => ({

--- a/src/views/recipeCollections/RecipeCollection.elements.tsx
+++ b/src/views/recipeCollections/RecipeCollection.elements.tsx
@@ -10,6 +10,7 @@ export const NanoRecipeCard = styled(Card)(({ theme }) => ({
     display: "flex",
     borderRadius: theme.shape.borderRadius,
     backgroundColor: theme.palette.background.default,
+    width: "100%",
 }));
 
 export const NanoCardContent = styled("div")(({ theme }) => ({

--- a/src/views/recipeCollections/RecipeGrid.tsx
+++ b/src/views/recipeCollections/RecipeGrid.tsx
@@ -1,16 +1,19 @@
 import { Grid } from "@mui/material";
 import RecipeCard from "@/features/RecipeLibrary/components/RecipeCard";
+import { NanoCard } from "@/views/recipeCollections/NanoCard";
 
 type RecipeDisplayGridProps = {
-    recipes: any;
-    me: any;
+    recipes: RecipeCard[];
+    me: any; //todo
     markAsMine: boolean;
+    cardType: "standard" | "nano";
 };
 
-export const RecipeGridDisplay = ({
+export const RecipeGrid = ({
     recipes,
     me,
     markAsMine,
+    cardType = "standard",
 }: RecipeDisplayGridProps) => {
     return (
         <Grid container spacing={4} alignItems="stretch">
@@ -23,12 +26,16 @@ export const RecipeGridDisplay = ({
                     key={recipe.id}
                     sx={{ display: "flex" }}
                 >
-                    <RecipeCard
-                        recipe={recipe}
-                        me={me}
-                        indicateMine={markAsMine}
-                        mine={recipe.owner.id === "" + me.id}
-                    />
+                    {cardType === "standard" ? (
+                        <RecipeCard
+                            recipe={recipe}
+                            me={me}
+                            indicateMine={markAsMine}
+                            mine={recipe.ownerId === "" + me.id}
+                        />
+                    ) : (
+                        <NanoCard recipe={recipe} isMine={markAsMine} />
+                    )}
                 </Grid>
             ))}
         </Grid>

--- a/src/views/recipeCollections/RecipeGrid.tsx
+++ b/src/views/recipeCollections/RecipeGrid.tsx
@@ -16,7 +16,7 @@ export const RecipeGrid = ({
     cardType = "standard",
 }: RecipeDisplayGridProps) => {
     return (
-        <Grid container spacing={4} alignItems="stretch">
+        <Grid container alignItems="stretch">
             {recipes.map((recipe) => (
                 <Grid
                     item

--- a/src/views/recipeCollections/RecipeListDisplay.tsx
+++ b/src/views/recipeCollections/RecipeListDisplay.tsx
@@ -13,7 +13,6 @@ type RecipeListDisplayProps = {
 
 export const RecipeListDisplay: React.FC<RecipeListDisplayProps> = ({
     recipes,
-    me,
     markAsMine,
 }) => {
     if (!recipes) {

--- a/src/views/recipeCollections/RecipeListDisplay.tsx
+++ b/src/views/recipeCollections/RecipeListDisplay.tsx
@@ -1,12 +1,12 @@
 import { Stack } from "@mui/material";
-import { RecipeListItem } from "@/features/LibrarySearch/components/RecipeListItem";
 import { UserType } from "@/global/types/identity";
 import { MessagePaper } from "@/features/RecipeLibrary/components/MessagePaper";
 import React from "react";
-import { RecipeType } from "@/features/RecipeLibrary/types";
+import { RecipeCard } from "@/features/RecipeLibrary/types";
+import { NanoCard } from "@/views/recipeCollections/NanoCard";
 
 type RecipeListDisplayProps = {
-    recipes?: RecipeType[];
+    recipes?: RecipeCard[];
     me: UserType;
     markAsMine: boolean;
 };
@@ -23,12 +23,7 @@ export const RecipeListDisplay: React.FC<RecipeListDisplayProps> = ({
     return (
         <Stack gap={1.5}>
             {recipes.map((recipe) => (
-                <RecipeListItem
-                    key={recipe.id}
-                    recipe={recipe}
-                    mine={recipe.owner.id === "" + me.id}
-                    markAsMine={markAsMine}
-                />
+                <NanoCard key={recipe.id} recipe={recipe} isMine={markAsMine} />
             ))}
         </Stack>
     );


### PR DESCRIPTION
This PR makes a few changes in adding a new feature to surface recommendations:

- Move the logic for a search out of the recipe list to make it a more dumb component
- Adds a new hook for fetching recommended recipes
- Moves some of the recipe display pieces to the view folder 
- Consolidating a few recipe types to create a bit more cohesion