### PR TITLE
nanocard ownership, grid reuse, and visual cleanup

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,7 @@ import pluginJsxRuntimeConfig from "eslint-plugin-react/configs/jsx-runtime.js";
 import pluginReactHooks_nonFlat from "eslint-plugin-react-hooks";
 
 export default [
+    { settings: { react: { version: "detect" } } },
     { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
     { languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } } },
     { languageOptions: { globals: globals.browser } },

--- a/package.json
+++ b/package.json
@@ -60,9 +60,10 @@
     "test:coverage": "vitest run --coverage --watch=false",
     "pretest": "npm run compile",
     "posttest": "eslint --max-warnings 0 ./src",
-    "lint": "eslint ./src",
+    "lint": "eslint ./src; tsc --noEmit",
     "lint:fix": "eslint --fix ./src",
     "format:write": "prettier . --write",
+    "watch": "tsc --watch --noEmit",
     "generate-pwa-assets": "pwa-assets-generator --preset minimal-2023 public/favicon-48x48.png"
   },
   "browserslist": {

--- a/src/data/RecipeActions.js
+++ b/src/data/RecipeActions.js
@@ -8,7 +8,11 @@ const sendToPlanShape = {
 };
 
 const RecipeActions = {
-    SEND_TO_PLAN: typedAction("recipe/send-to-plan", sendToPlanShape),
+    SEND_TO_PLAN: typedAction("recipe/send-to-plan", {
+        ...sendToPlanShape,
+        recipeId: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+            .isRequired,
+    }),
     SENT_TO_PLAN: typedAction("recipe/sent-to-plan", sendToPlanShape),
     ERROR_SENDING_TO_PLAN: typedAction(
         "recipe/error-sending-to-plan",

--- a/src/data/hooks/fragments.ts
+++ b/src/data/hooks/fragments.ts
@@ -35,6 +35,7 @@ fragment librarySearchResult on RecipeConnection {
       owner {
         id
         imageUrl
+        email
         name
       }
       photo {

--- a/src/features/LibrarySearch/LibrarySearchController.tsx
+++ b/src/features/LibrarySearch/LibrarySearchController.tsx
@@ -65,13 +65,13 @@ export const LibrarySearchController: React.FC<
                                 <RecipeListDisplay
                                     recipes={recipes}
                                     me={me}
-                                    markAsMine={markAsMine}
+                                    showOwner={markAsMine}
                                 />
                             ) : (
                                 <RecipeGrid
                                     recipes={recipes}
                                     me={me}
-                                    markAsMine={markAsMine}
+                                    showOwner={markAsMine}
                                     cardType="standard"
                                 />
                             )}

--- a/src/features/LibrarySearch/LibrarySearchController.tsx
+++ b/src/features/LibrarySearch/LibrarySearchController.tsx
@@ -46,6 +46,9 @@ export const LibrarySearchController: React.FC<
 
     const markAsMine = scope === LibrarySearchScope.Everyone;
 
+    // if there are already recipes from cache, don't show the spinner
+    const showLoading = loading && (!recipes || recipes.length === 0);
+
     return (
         <>
             <SearchInput
@@ -54,7 +57,7 @@ export const LibrarySearchController: React.FC<
                 onSearch={onSearch}
             />
             <SearchResults>
-                {loading && <LoadingIndicator />}
+                {showLoading && <LoadingIndicator />}
                 <ScalingProvider>
                     {recipes && (
                         <>

--- a/src/features/RecipeDisplay/components/RecipeDetail.tsx
+++ b/src/features/RecipeDisplay/components/RecipeDetail.tsx
@@ -123,8 +123,7 @@ const RecipeDetail: React.FC<Props> = ({
                     {photo ? (
                         <ItemImage
                             className={classes.imageContainer}
-                            image={photo.url}
-                            focus={photo.focus}
+                            photo={photo}
                             alt={recipe.name}
                         />
                     ) : (

--- a/src/features/RecipeLibrary/LibraryController.tsx
+++ b/src/features/RecipeLibrary/LibraryController.tsx
@@ -10,11 +10,8 @@ import LoadingIndicator from "@/views/common/LoadingIndicator";
 import { SearchRecipes } from "@/features/RecipeLibrary/components/SearchRecipes";
 import { useScrollTrigger } from "@mui/material";
 import { useIsMobile } from "@/providers/IsMobile";
-import { useRecommendedRecipes } from "@/features/RecipeLibrary/hooks/useRecommendedRecipes";
-import { RecipeGrid } from "@/views/recipeCollections/RecipeGrid";
-import { SectionHeadline } from "@/global/elements/typography.elements";
 import useIsDevMode from "@/data/useIsDevMode";
-import Button from "@mui/material/Button";
+import Recommendations from "@/features/RecipeLibrary/components/Recommendations";
 
 /**
  * TODO: Issue-218
@@ -55,9 +52,6 @@ export const LibraryController = () => {
         scope,
         query,
     });
-
-    const { data: recommended, fetchMore: fetchMoreRecommended } =
-        useRecommendedRecipes(isMobile ? 3 : 9);
 
     function handleSearchChange(e) {
         setUnsavedQuery(e.target.value);
@@ -105,11 +99,9 @@ export const LibraryController = () => {
         });
     }
 
-    const markAsMine = scope === LibrarySearchScope.Everyone;
+    const showRecommendations = devMode && query === "";
 
-    const showRecommendations = devMode && query === "" && recommended;
-
-    if (loading) {
+    if (loading && (!recipes || recipes.length === 0)) {
         return <LoadingIndicator />;
     }
 
@@ -126,33 +118,7 @@ export const LibraryController = () => {
                 toggleScope={toggleScope}
             />
             <ScalingProvider>
-                {showRecommendations && (
-                    <>
-                        <SectionHeadline>Recommended</SectionHeadline>
-                        <RecipeGrid
-                            recipes={recommended.results}
-                            me={me}
-                            markAsMine={markAsMine}
-                            cardType="nano"
-                        />
-                        {recommended?.pageInfo?.hasNextPage && (
-                            <Button
-                                variant="text"
-                                onClick={() =>
-                                    fetchMoreRecommended({
-                                        variables: {
-                                            after: recommended?.pageInfo
-                                                ?.endCursor,
-                                        },
-                                    })
-                                }
-                            >
-                                Show More
-                            </Button>
-                        )}
-                        <SectionHeadline>All Recipes</SectionHeadline>
-                    </>
-                )}
+                {showRecommendations && <Recommendations />}
                 <RecipesList
                     me={me}
                     isMobile={isMobile}

--- a/src/features/RecipeLibrary/components/ItemImage.tsx
+++ b/src/features/RecipeLibrary/components/ItemImage.tsx
@@ -1,30 +1,24 @@
 import { CardMedia, SxProps, useTheme } from "@mui/material";
 import React from "react";
 import { CommonProps } from "@mui/material/OverridableComponent";
-import { Maybe } from "graphql/jsutils/Maybe";
 import { Theme } from "@mui/material/styles";
+import { Photo } from "@/__generated__/graphql";
 
 interface Props extends CommonProps {
-    image: string;
-    focus?: Maybe<number[]>;
+    photo: Photo;
     alt: string;
     sx?: SxProps<Theme>;
 }
 
-const ItemImage: React.FC<Props> = ({
-    image,
-    focus,
-    alt,
-    sx = {},
-    ...props
-}) => {
-    const x = focus ? focus[0] * 100 : 50;
-    const y = focus ? focus[1] * 100 : 50;
+const ItemImage: React.FC<Props> = ({ photo, alt, sx = {}, ...props }) => {
     const theme = useTheme();
+    const f = photo.focus;
+    const x = f ? f[0] * 100 : 50;
+    const y = f ? f[1] * 100 : 50;
 
     return (
         <CardMedia
-            image={image}
+            image={photo.url}
             title={alt}
             {...props}
             sx={{

--- a/src/features/RecipeLibrary/components/RecipeCard.tsx
+++ b/src/features/RecipeLibrary/components/RecipeCard.tsx
@@ -70,22 +70,21 @@ const RecipeCard: React.FC<Props> = ({ recipe, mine, showOwner }) => {
             }}
         >
             <>
-                <Link to={`/library/recipe/${recipe.id}`}>
-                    {recipe.photo ? (
+                {recipe.photo ? (
+                    <Link to={`/library/recipe/${recipe.id}`}>
                         <ItemImage
                             className={classes.photo}
-                            image={recipe.photo}
-                            focus={recipe.photoFocus}
+                            photo={recipe.photo}
                             alt={recipe.name}
                         />
-                    ) : (
-                        <ItemImageUpload
-                            recipeId={recipe.id}
-                            disabled={!mine}
-                            notOnPaper
-                        />
-                    )}
-                </Link>
+                    </Link>
+                ) : (
+                    <ItemImageUpload
+                        recipeId={recipe.id}
+                        disabled={!mine}
+                        notOnPaper
+                    />
+                )}
                 <CardContent style={{ flexGrow: 2 }}>
                     <Grid container alignItems={"start"} wrap={"nowrap"}>
                         <Grid item>
@@ -120,10 +119,10 @@ const RecipeCard: React.FC<Props> = ({ recipe, mine, showOwner }) => {
                             text={<Source url={recipe.externalUrl} />}
                         />
                     )}
-                    {recipe.recipeYield && (
+                    {recipe.yield && (
                         <RecipeInfo
                             label="Yield"
-                            text={`${recipe.recipeYield} servings`}
+                            text={`${recipe.yield} servings`}
                         />
                     )}
                     {recipe.totalTime && (

--- a/src/features/RecipeLibrary/components/RecipeCard.tsx
+++ b/src/features/RecipeLibrary/components/RecipeCard.tsx
@@ -9,9 +9,7 @@ import {
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import Dispatcher from "@/data/dispatcher";
-import FriendStore from "@/data/FriendStore";
 import RecipeActions from "@/data/RecipeActions";
-import useFluxStore from "@/data/useFluxStore";
 import ItemImage from "@/features/RecipeLibrary/components/ItemImage";
 import ItemImageUpload from "@/features/RecipeLibrary/components/ItemImageUpload";
 import SendToPlan from "@/features/RecipeLibrary/components/SendToPlan";
@@ -24,7 +22,7 @@ import User from "@/views/user/User";
 import FavoriteIndicator from "../../Favorites/components/Indicator";
 import LabelItem from "@/global/components/LabelItem";
 import { TaskBar, TaskBarButton } from "@/global/elements/taskbar.elements";
-import { RecipeCard } from "@/features/RecipeLibrary/types";
+import { RecipeCard as TRecipeCard } from "@/features/RecipeLibrary/types";
 
 const useStyles = makeStyles({
     photo: {
@@ -37,21 +35,12 @@ const useStyles = makeStyles({
 });
 
 interface Props {
-    recipe: RecipeCard;
+    recipe: TRecipeCard;
     mine: boolean;
-    indicateMine: boolean;
-    me: any; // todo
+    showOwner: boolean;
 }
 
-const RecipeCard: React.FC<Props> = ({ recipe, mine, indicateMine, me }) => {
-    const owner = useFluxStore(
-        () => {
-            if (mine) return indicateMine ? me : null;
-            return FriendStore.getFriendRlo(recipe.ownerId).data;
-        },
-        [FriendStore],
-        [mine, indicateMine, me, recipe.ownerId],
-    );
+const RecipeCard: React.FC<Props> = ({ recipe, mine, showOwner }) => {
     const classes = useStyles();
     const [raised, setRaised] = React.useState(false);
 
@@ -115,13 +104,13 @@ const RecipeCard: React.FC<Props> = ({ recipe, mine, indicateMine, me }) => {
                             </Typography>
                         </Grid>
                         <Grid item>
-                            {owner && (
+                            {showOwner && (
                                 <div
                                     style={{
                                         float: "right",
                                     }}
                                 >
-                                    <User {...owner} iconOnly inline />
+                                    <User {...recipe.owner} iconOnly inline />
                                 </div>
                             )}
                         </Grid>

--- a/src/features/RecipeLibrary/components/RecipeCard.tsx
+++ b/src/features/RecipeLibrary/components/RecipeCard.tsx
@@ -51,8 +51,7 @@ const RecipeCard: React.FC<Props> = ({ recipe, mine, showOwner }) => {
     const handleClick = (planId: number, scale?: number) => {
         Dispatcher.dispatch({
             type: RecipeActions.SEND_TO_PLAN,
-            recipeId:
-                typeof recipe.id === "string" ? parseInt(recipe.id) : recipe.id,
+            recipeId: recipe.id,
             planId,
             scale: scale ? scale : 1,
         });

--- a/src/features/RecipeLibrary/components/RecipesList.tsx
+++ b/src/features/RecipeLibrary/components/RecipesList.tsx
@@ -1,6 +1,5 @@
 import { AddRecipeIcon } from "@/views/common/icons";
 import { Container as Content, Grid } from "@mui/material";
-import RecipeCard from "@/features/RecipeLibrary/components/RecipeCard";
 import React from "react";
 import history from "@/util/history";
 import FoodingerFab from "@/views/common/FoodingerFab";
@@ -8,6 +7,8 @@ import LazyInfinite from "@/views/common/LazyInfinite";
 import LoadingIndicator from "@/views/common/LoadingIndicator";
 import { LibrarySearchScope } from "@/__generated__/graphql";
 import { MessagePaper } from "@/features/RecipeLibrary/components/MessagePaper";
+import { RecipeCard as TRecipeCard } from "@/features/RecipeLibrary/types";
+import { RecipeGrid } from "@/views/recipeCollections/RecipeGrid";
 
 interface RecipesListProps {
     me: any; // todo
@@ -15,7 +16,7 @@ interface RecipesListProps {
     scope?: LibrarySearchScope;
     isLoading: boolean;
     isComplete: boolean;
-    recipes?: RecipeCard[];
+    recipes?: TRecipeCard[];
 
     onSearch(filter: string, scope: LibrarySearchScope): void;
 
@@ -42,26 +43,13 @@ export const RecipesList: React.FC<RecipesListProps> = ({
                     complete={isComplete}
                     onNeedMore={onNeedMore}
                 >
-                    <Grid container spacing={4} alignItems="stretch">
-                        {recipes.map((recipe) => (
-                            <Grid
-                                item
-                                md={4}
-                                sm={6}
-                                xs={12}
-                                key={recipe.id}
-                                sx={{ display: "flex" }}
-                            >
-                                <RecipeCard
-                                    recipe={recipe}
-                                    me={me}
-                                    indicateMine={
-                                        scope === LibrarySearchScope.Everyone
-                                    }
-                                    mine={recipe.ownerId === "" + me.id}
-                                />
-                            </Grid>
-                        ))}
+                    <RecipeGrid
+                        recipes={recipes}
+                        me={me}
+                        showOwner={scope === LibrarySearchScope.Everyone}
+                        cardType={"standard"}
+                        spacing={4}
+                    >
                         {isComplete && recipes.length > 5 && (
                             <Grid item xs={12}>
                                 <MessagePaper
@@ -74,7 +62,7 @@ export const RecipesList: React.FC<RecipesListProps> = ({
                                 <LoadingIndicator primary={"Searching..."} />
                             </Grid>
                         )}
-                    </Grid>
+                    </RecipeGrid>
                 </LazyInfinite>
             );
         } else if (isLoading) {

--- a/src/features/RecipeLibrary/components/Recommendations.tsx
+++ b/src/features/RecipeLibrary/components/Recommendations.tsx
@@ -1,0 +1,46 @@
+import { SectionHeadline } from "@/global/elements/typography.elements";
+import { RecipeGrid } from "@/views/recipeCollections/RecipeGrid";
+import Button from "@mui/material/Button";
+import { useRecommendedRecipes } from "@/features/RecipeLibrary/hooks/useRecommendedRecipes";
+import { useIsMobile } from "@/providers/IsMobile";
+import { useProfile } from "@/providers/Profile";
+
+function Recommendations() {
+    const isMobile = useIsMobile();
+    const me = useProfile();
+    const { data: recommended, fetchMore: fetchMoreRecommended } =
+        useRecommendedRecipes(isMobile ? 3 : 9);
+
+    if (!recommended?.results || recommended.results.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            <SectionHeadline>Recommended</SectionHeadline>
+            <RecipeGrid
+                recipes={recommended.results}
+                me={me}
+                showOwner={true}
+                cardType="nano"
+            />
+            {recommended?.pageInfo?.hasNextPage && (
+                <Button
+                    variant="text"
+                    onClick={() =>
+                        fetchMoreRecommended({
+                            variables: {
+                                after: recommended?.pageInfo?.endCursor,
+                            },
+                        })
+                    }
+                >
+                    Show More
+                </Button>
+            )}
+            <SectionHeadline>All Recipes</SectionHeadline>
+        </>
+    );
+}
+
+export default Recommendations;

--- a/src/features/RecipeLibrary/data/LibraryStore.js
+++ b/src/features/RecipeLibrary/data/LibraryStore.js
@@ -86,7 +86,9 @@ class LibraryStore extends ReduceStore {
 
             case RecipeActions.SEND_TO_PLAN: {
                 RecipeApi.sendToPlan(
-                    action.recipeId,
+                    typeof action.recipeId === "string"
+                        ? parseInt(action.recipeId)
+                        : action.recipeId,
                     action.planId,
                     action.scale,
                 );

--- a/src/features/RecipeLibrary/hooks/useRecommendedRecipes.ts
+++ b/src/features/RecipeLibrary/hooks/useRecommendedRecipes.ts
@@ -1,7 +1,6 @@
 import { gql } from "@/__generated__";
 import useAdaptingQuery from "@/data/hooks/useAdaptingQuery";
 import { Results } from "@/data/types";
-import { BfsId } from "@/global/types/identity";
 import { RecipeCard } from "@/features/RecipeLibrary/types";
 import { GetRecipeSuggestionsQuery } from "@/__generated__/graphql";
 
@@ -30,22 +29,7 @@ function adapter(
     const { edges, pageInfo } = result;
 
     return {
-        results: edges.map((it) => {
-            const recipe = it.node;
-            return {
-                calories: recipe?.calories,
-                externalUrl: recipe?.externalUrl,
-                favorite: recipe?.favorite,
-                id: recipe?.id as BfsId,
-                labels: recipe?.labels ?? [],
-                name: recipe?.name ?? "",
-                owner: recipe?.owner,
-                photo: recipe?.photo?.url ?? null,
-                photoFocus: recipe?.photo?.focus ?? [],
-                recipeYield: recipe?.yield,
-                totalTime: recipe?.totalTime,
-            };
-        }),
+        results: edges.map((it) => it.node),
         pageInfo,
     };
 }

--- a/src/features/RecipeLibrary/hooks/useRecommendedRecipes.ts
+++ b/src/features/RecipeLibrary/hooks/useRecommendedRecipes.ts
@@ -39,7 +39,7 @@ function adapter(
                 id: recipe?.id as BfsId,
                 labels: recipe?.labels ?? [],
                 name: recipe?.name ?? "",
-                ownerId: recipe?.owner.id,
+                owner: recipe?.owner,
                 photo: recipe?.photo?.url ?? null,
                 photoFocus: recipe?.photo?.focus ?? [],
                 recipeYield: recipe?.yield,

--- a/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
+++ b/src/features/RecipeLibrary/hooks/useSearchLibrary.ts
@@ -1,6 +1,5 @@
 import { SEARCH_RECIPES } from "@/features/RecipeLibrary/data/queries";
 import { QueryResult, useQuery } from "@apollo/client";
-import type { RecipeCard } from "@/features/RecipeLibrary/types";
 
 interface UseSearchLibraryQueryResult
     extends Pick<
@@ -26,22 +25,6 @@ export const useSearchLibrary = ({
         },
     );
 
-    // e.node
-    const recipes: RecipeCard[] =
-        data?.library?.recipes.edges.map((it) => ({
-            id: it.node.id,
-            name: it.node.name,
-            owner: it.node.owner,
-            calories: it.node.calories || null,
-            externalUrl: it.node.externalUrl || null,
-            favorite: it.node.favorite,
-            labels: it.node.labels || [],
-            photo: it.node.photo?.url || null,
-            photoFocus: it.node.photo?.focus || null,
-            totalTime: it.node.totalTime || null,
-            recipeYield: it.node.yield || null,
-        })) || [];
-
     return {
         loading,
         error,
@@ -49,6 +32,6 @@ export const useSearchLibrary = ({
         fetchMore,
         isComplete: !data?.library?.recipes.pageInfo.hasNextPage,
         endCursor: data?.library?.recipes.pageInfo.endCursor,
-        data: recipes,
+        data: data?.library?.recipes.edges.map((it) => it.node) || [],
     };
 };

--- a/src/features/RecipeLibrary/types.ts
+++ b/src/features/RecipeLibrary/types.ts
@@ -1,9 +1,16 @@
-import { Recipe } from "@/global/types/types";
-import { UserType } from "@/global/types/identity";
+import { Recipe, User } from "@/__generated__/graphql";
 
-export type RecipeCard = Omit<
+export type RecipeCard = Pick<
     Recipe,
-    "directions" | "ingredients" | "libraryRecipeId" | "ownerId"
+    | "id"
+    | "calories"
+    | "externalUrl"
+    | "favorite"
+    | "labels"
+    | "name"
+    | "photo"
+    | "yield"
+    | "totalTime"
 > & {
-    owner: Pick<UserType, "id" | "name" | "email" | "imageUrl">;
+    owner: Pick<User, "id" | "name" | "email" | "imageUrl">;
 };

--- a/src/features/RecipeLibrary/types.ts
+++ b/src/features/RecipeLibrary/types.ts
@@ -1,21 +1,9 @@
-import { Photo, User as UserType } from "@/__generated__/graphql";
 import { Recipe } from "@/global/types/types";
+import { UserType } from "@/global/types/identity";
 
 export type RecipeCard = Omit<
     Recipe,
-    "directions" | "ingredients" | "libraryRecipeId"
->;
-
-export interface RecipeType {
-    id: string;
-    calories?: number | null;
-    directions?: string;
-    externalUrl?: string | null;
-    favorite: boolean;
-    labels?: string[] | null;
-    name: string;
-    owner: UserType;
-    photo?: Photo | null;
-    totalTime?: number | null;
-    yield?: number | null;
-}
+    "directions" | "ingredients" | "libraryRecipeId" | "ownerId"
+> & {
+    owner: Pick<UserType, "id" | "name" | "email" | "imageUrl">;
+};

--- a/src/global/elements/taskbar.elements.ts
+++ b/src/global/elements/taskbar.elements.ts
@@ -4,8 +4,8 @@ import { IconButton } from "@mui/material";
 export const TaskBar = styled("div")(({ theme }) => ({
     display: "flex",
     gap: theme.spacing(0.5),
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(1),
+    marginTop: theme.spacing(0.5),
+    marginBottom: theme.spacing(0.5),
 }));
 
 export const TaskBarButton = styled(IconButton)(({ theme }) => ({

--- a/src/global/elements/typography.elements.ts
+++ b/src/global/elements/typography.elements.ts
@@ -1,26 +1,11 @@
 import { styled } from "@mui/material/styles";
 import { Link } from "react-router-dom";
 
-export const SmallHeadline = styled("span")({
-    fontFamily: "'Encode Sans', sans-serif",
-    fontSize: "1rem",
-    fontWeight: "bold",
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    padding: 0,
-    margin: 0,
-});
-
 export const SectionHeadline = styled("h3")(({ theme }) => ({
     fontFamily: "'Encode Sans', sans-serif",
     fontSize: "1.2rem",
     marginBottom: theme.spacing(1),
     borderBottom: `1px solid ${theme.palette.divider}`,
-}));
-
-export const SmallLabel = styled("span")(({ theme }) => ({
-    color: theme.palette.text.primary,
-    fontSize: `12px`,
 }));
 
 export const LinkTitle = styled(Link)(({ theme }) => ({
@@ -29,6 +14,7 @@ export const LinkTitle = styled(Link)(({ theme }) => ({
     fontSize: "1rem",
     fontWeight: "bold",
     margin: 0,
+    whiteSpace: "nowrap",
     overflow: "hidden",
     padding: 0,
     textOverflow: "ellipsis",

--- a/src/global/types/types.ts
+++ b/src/global/types/types.ts
@@ -1,5 +1,5 @@
 import { CheckableActionType } from "@/util/typedAction";
-import { BfsId, UserType } from "@/global/types/identity";
+import { BfsId } from "@/global/types/identity";
 import { PlannedRecipeHistory, User } from "@/__generated__/graphql";
 
 type IngredientType = "Recipe" | "PantryItem";
@@ -94,14 +94,6 @@ export type RecipeHistory = Pick<
     owner: Pick<User, "name" | "email" | "imageUrl">;
 };
 
-export interface FullRecipe {
-    recipe: Recipe;
-    subrecipes: Subrecipe[];
-    planHistory: RecipeHistory[];
-    mine: boolean;
-    owner: Omit<UserType, "provider" | "roles">;
-}
-
 export interface SharedRecipe extends Pick<Recipe, "id"> {
     secret: string;
     slug: string;
@@ -117,14 +109,6 @@ export interface FluxAction {
     type: CheckableActionType;
 
     [k: string]: any;
-}
-
-export interface Page<E> {
-    page: number;
-    pageSize: number;
-    first: boolean;
-    last: boolean;
-    content: E[];
 }
 
 export type FormValue = string | number | number[] | string[] | File | null;

--- a/src/views/recipeCollections/NanoCard.tsx
+++ b/src/views/recipeCollections/NanoCard.tsx
@@ -58,9 +58,8 @@ export const NanoCard: React.FC<RecipeListItemProps> = ({
                         order: 2,
                         overflow: "hidden",
                     }}
-                    image={recipe.photo}
+                    photo={recipe.photo}
                     alt={recipe.name}
-                    focus={recipe.photoFocus}
                 />
             )}
             <NanoCardContent>
@@ -93,11 +92,9 @@ export const NanoCard: React.FC<RecipeListItemProps> = ({
     );
 };
 
-const Labels: React.FC<BoxProps & { labels: string[] }> = ({
+const Labels: React.FC<BoxProps & { labels: Maybe<string[]> }> = ({
     labels,
     ...passthrough
-}: {
-    labels: string[];
 }) => {
     if (!labels || labels.length === 0) return null;
     return (

--- a/src/views/recipeCollections/NanoCard.tsx
+++ b/src/views/recipeCollections/NanoCard.tsx
@@ -17,6 +17,7 @@ import ItemImage from "@/features/RecipeLibrary/components/ItemImage";
 import { styled } from "@mui/material/styles";
 import { BoxProps } from "@mui/material/Box/Box";
 import User from "@/views/user/User";
+import { Maybe } from "@/__generated__/graphql";
 
 type RecipeListItemProps = {
     recipe: RecipeCard;
@@ -37,8 +38,7 @@ export const NanoCard: React.FC<RecipeListItemProps> = ({
     const handleClick = (planId: number, scale?: number) => {
         Dispatcher.dispatch({
             type: RecipeActions.SEND_TO_PLAN,
-            recipeId:
-                typeof recipe.id === "string" ? parseInt(recipe.id) : recipe.id,
+            recipeId: recipe.id,
             planId,
             scale: scale ? scale : 1,
         });

--- a/src/views/recipeCollections/NanoCard.tsx
+++ b/src/views/recipeCollections/NanoCard.tsx
@@ -11,9 +11,11 @@ import {
     NanoRecipeCard,
 } from "@/views/recipeCollections/RecipeCollection.elements";
 import { TaskBar, TaskBarButton } from "@/global/elements/taskbar.elements";
-import { LinkTitle, SmallLabel } from "@/global/elements/typography.elements";
+import { LinkTitle } from "@/global/elements/typography.elements";
 import { Link } from "react-router-dom";
 import ItemImage from "@/features/RecipeLibrary/components/ItemImage";
+import { styled } from "@mui/material/styles";
+import { BoxProps } from "@mui/material/Box/Box";
 
 type RecipeListItemProps = {
     recipe: RecipeCard;
@@ -42,6 +44,7 @@ export const NanoCard: React.FC<RecipeListItemProps> = ({ recipe, isMine }) => {
             raised={raised}
             onMouseEnter={() => setRaised(true)}
             onMouseLeave={() => setRaised(false)}
+            title={recipe.name}
         >
             {recipe.photo && (
                 <ItemImage
@@ -77,17 +80,40 @@ export const NanoCard: React.FC<RecipeListItemProps> = ({ recipe, isMine }) => {
                 <LinkTitle to={`/library/recipe/${recipe.id}`}>
                     {recipe.name}
                 </LinkTitle>
-                {labelsToDisplay && (
-                    <Box my={0.5}>
-                        {labelsToDisplay.map((label, idx) => (
-                            <React.Fragment key={label}>
-                                <SmallLabel>{label}</SmallLabel>
-                                {idx < labelsToDisplay.length - 1 && ", "}
-                            </React.Fragment>
-                        ))}
-                    </Box>
-                )}
+                <Labels mt={0.25} labels={labelsToDisplay} />
             </NanoCardContent>
         </NanoRecipeCard>
     );
 };
+
+const Labels: React.FC<BoxProps & { labels: string[] }> = ({
+    labels,
+    ...passthrough
+}: {
+    labels: string[];
+}) => {
+    if (!labels || labels.length === 0) return null;
+    return (
+        <Lbls title={labels.join(", ")} {...passthrough}>
+            {labels.map((label) => (
+                <Lbl key={label}>{label}</Lbl>
+            ))}
+        </Lbls>
+    );
+};
+
+const Lbls = styled(Box)({
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+});
+
+const Lbl = styled("span")({
+    fontSize: `12px`,
+    ":before": {
+        content: "', '",
+    },
+    ":first-of-type:before": {
+        content: "''",
+    },
+});

--- a/src/views/recipeCollections/NanoCard.tsx
+++ b/src/views/recipeCollections/NanoCard.tsx
@@ -16,14 +16,19 @@ import { Link } from "react-router-dom";
 import ItemImage from "@/features/RecipeLibrary/components/ItemImage";
 import { styled } from "@mui/material/styles";
 import { BoxProps } from "@mui/material/Box/Box";
+import User from "@/views/user/User";
 
 type RecipeListItemProps = {
     recipe: RecipeCard;
-    isMine: boolean;
+    mine: boolean;
+    showOwner: boolean;
 };
 
-// TODO: add owner indicator?
-export const NanoCard: React.FC<RecipeListItemProps> = ({ recipe, isMine }) => {
+export const NanoCard: React.FC<RecipeListItemProps> = ({
+    recipe,
+    mine,
+    showOwner,
+}) => {
     const [raised, setRaised] = React.useState(false);
     const labelsToDisplay =
         recipe.labels &&
@@ -68,13 +73,15 @@ export const NanoCard: React.FC<RecipeListItemProps> = ({ recipe, isMine }) => {
                     >
                         <ViewIcon />
                     </TaskBarButton>
-                    {isMine && (
+                    {mine ? (
                         <TaskBarButton
                             component={Link}
                             to={`/library/recipe/${recipe.id}/edit`}
                         >
                             <EditIcon />
                         </TaskBarButton>
+                    ) : (
+                        showOwner && <User {...recipe.owner} iconOnly inline />
                     )}
                 </TaskBar>
                 <LinkTitle to={`/library/recipe/${recipe.id}`}>

--- a/src/views/recipeCollections/RecipeCollection.elements.tsx
+++ b/src/views/recipeCollections/RecipeCollection.elements.tsx
@@ -9,16 +9,13 @@ export const SearchResults = styled(Box)(({ theme }) => ({
 export const NanoRecipeCard = styled(Card)(({ theme }) => ({
     display: "flex",
     borderRadius: theme.shape.borderRadius,
-    backgroundColor: theme.palette.background.default,
+    backgroundColor: theme.palette.background.paper,
     width: "100%",
-    margin: theme.spacing(1),
-    paddingTop: theme.spacing(1),
 }));
 
 export const NanoCardContent = styled("div")(({ theme }) => ({
-    padding: theme.spacing(1),
+    padding: `0 ${theme.spacing(0.5)}`,
     display: "flex",
     width: "80%",
     flexDirection: "column",
-    backgroundColor: theme.palette.background.paper,
 }));

--- a/src/views/recipeCollections/RecipeGrid.tsx
+++ b/src/views/recipeCollections/RecipeGrid.tsx
@@ -16,7 +16,7 @@ export const RecipeGrid = ({
     cardType = "standard",
 }: RecipeDisplayGridProps) => {
     return (
-        <Grid container alignItems="stretch">
+        <Grid container alignItems="stretch" spacing={2}>
             {recipes.map((recipe) => (
                 <Grid
                     item

--- a/src/views/recipeCollections/RecipeGrid.tsx
+++ b/src/views/recipeCollections/RecipeGrid.tsx
@@ -1,22 +1,30 @@
 import { Grid } from "@mui/material";
 import RecipeCard from "@/features/RecipeLibrary/components/RecipeCard";
 import { NanoCard } from "@/views/recipeCollections/NanoCard";
+import { RecipeCard as TRecipeCard } from "@/features/RecipeLibrary/types";
+import { PropsWithChildren } from "react";
+import { UserType } from "@/global/types/identity";
 
-type RecipeDisplayGridProps = {
-    recipes: RecipeCard[];
-    me: any; //todo
-    markAsMine: boolean;
+type RecipeDisplayGridProps = PropsWithChildren & {
+    recipes: TRecipeCard[];
+    me: Pick<UserType, "id">;
+    showOwner: boolean;
     cardType: "standard" | "nano";
+    spacing?: number;
 };
 
 export const RecipeGrid = ({
     recipes,
     me,
-    markAsMine,
+    showOwner,
     cardType = "standard",
+    spacing = 2,
+    children,
 }: RecipeDisplayGridProps) => {
+    const myId = "" + me.id;
+    const isMine = (r) => r.owner.id === myId;
     return (
-        <Grid container alignItems="stretch" spacing={2}>
+        <Grid container alignItems="stretch" spacing={spacing}>
             {recipes.map((recipe) => (
                 <Grid
                     item
@@ -29,15 +37,19 @@ export const RecipeGrid = ({
                     {cardType === "standard" ? (
                         <RecipeCard
                             recipe={recipe}
-                            me={me}
-                            indicateMine={markAsMine}
-                            mine={recipe.ownerId === "" + me.id}
+                            showOwner={showOwner}
+                            mine={isMine(recipe)}
                         />
                     ) : (
-                        <NanoCard recipe={recipe} isMine={markAsMine} />
+                        <NanoCard
+                            recipe={recipe}
+                            showOwner={showOwner}
+                            mine={isMine(recipe)}
+                        />
                     )}
                 </Grid>
             ))}
+            {children}
         </Grid>
     );
 };

--- a/src/views/recipeCollections/RecipeListDisplay.tsx
+++ b/src/views/recipeCollections/RecipeListDisplay.tsx
@@ -7,22 +7,31 @@ import { NanoCard } from "@/views/recipeCollections/NanoCard";
 
 type RecipeListDisplayProps = {
     recipes?: RecipeCard[];
-    me: UserType;
-    markAsMine: boolean;
+    me: Pick<UserType, "id">;
+    showOwner: boolean;
 };
 
 export const RecipeListDisplay: React.FC<RecipeListDisplayProps> = ({
     recipes,
-    markAsMine,
+    me,
+    showOwner,
 }) => {
     if (!recipes) {
         return <MessagePaper primary="Nothing matches that search." />;
     }
 
+    const myId = "" + me.id;
+    const isMine = (r) => r.owner.id === myId;
+
     return (
         <Stack gap={1.5}>
             {recipes.map((recipe) => (
-                <NanoCard key={recipe.id} recipe={recipe} isMine={markAsMine} />
+                <NanoCard
+                    key={recipe.id}
+                    recipe={recipe}
+                    mine={isMine(recipe)}
+                    showOwner={showOwner}
+                />
             ))}
         </Stack>
     );


### PR DESCRIPTION
While this started as "don't wrap nanocard labels", it's grown to encompass some layout improvements, reuse of card layouts, edit/owner on nanocards, and using on-recipe ownership info for all cards (instead of getting friends from the store by ID).