### PR TITLE
profile from graphql

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -546,12 +546,13 @@ type UnitOfMeasure implements Node {
     name: String!
 }
 
-type User {
-    email: String
+type User implements Node {
+    email: String!
     id: ID!
     imageUrl: String
     name: String
-    provider: String
+    provider: String!
+    roles: [String!]!
 }
 
 enum AccessLevel {

--- a/src/data/hooks/useAdaptingQuery.ts
+++ b/src/data/hooks/useAdaptingQuery.ts
@@ -32,7 +32,7 @@ export default function useAdaptingQuery<
         data: TData | undefined,
         result: QueryResult<TData, TVariables> | ApolloQueryResult<TData>,
     ) => TAdaptedData,
-    options: QueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>,
+    options?: QueryHookOptions<NoInfer<TData>, NoInfer<TVariables>>,
 ) {
     const raw = useQuery(query, options);
 

--- a/src/data/useAllPlansRLO.ts
+++ b/src/data/useAllPlansRLO.ts
@@ -16,7 +16,7 @@ export default function useAllPlansRLO() {
                         (p.acl ? p.acl.ownerId : undefined) ||
                         Number.MAX_SAFE_INTEGER;
                     let ownerName = "";
-                    if (ownerId === myId) {
+                    if ("" + ownerId === myId) {
                         ownerId = -1;
                     } else {
                         const rlo = friendStore.getFriendRlo(ownerId);

--- a/src/features/Planner/components/PlanSidebar.tsx
+++ b/src/features/Planner/components/PlanSidebar.tsx
@@ -49,7 +49,7 @@ function UserContent({
     return (
         <Grid
             container
-            spacing={1}
+            spacing={0.5}
             justifyContent="space-between"
             alignItems="center"
         >
@@ -66,6 +66,8 @@ function UserContent({
                         onChange={(e) =>
                             handleGrantChange(friend.id, e.target.value)
                         }
+                        variant={undefined}
+                        size={"small"}
                     >
                         <MenuItem value={LEVEL_NO_ACCESS}>No Access</MenuItem>
                         {/*VIEW too!*/}
@@ -131,7 +133,7 @@ const PlanSidebar: React.FC<Props> = ({ open, onClose, plan }) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const acl = plan.acl!;
     const grants = acl.grants || {};
-    const isMine = acl.ownerId === me.id;
+    const isMine = "" + acl.ownerId === me.id;
     const owner = isMine ? me : friendsById.get(acl.ownerId);
     const isAdministrator =
         isMine || includesLevel(grants[me.id], AccessLevel.ADMINISTER);

--- a/src/global/types/identity.ts
+++ b/src/global/types/identity.ts
@@ -1,10 +1,8 @@
+import { User } from "@/__generated__/graphql";
+
 export type BfsId = string | number;
 
-export interface UserType {
-    id: BfsId;
-    name: string | null;
-    provider: string;
-    email: string | null;
-    imageUrl: string | null;
-    roles: string[];
-}
+export type UserType = Pick<
+    User,
+    "id" | "name" | "provider" | "email" | "imageUrl" | "roles"
+>;

--- a/src/providers/ApolloClient.tsx
+++ b/src/providers/ApolloClient.tsx
@@ -10,8 +10,9 @@ import { API_BASE_URL } from "@/constants";
 import { askUserToReauth, isAuthError } from "./Profile";
 import createUploadLink from "apollo-upload-client/createUploadLink.mjs";
 
-const errorLink = onError(({ graphQLErrors }) => {
-    if (!graphQLErrors) return;
+const errorLink = onError(({ operation, graphQLErrors }) => {
+    // don't ask about reauth if requesting me; that's the profile gate
+    if (!graphQLErrors || operation.operationName === "me") return;
     graphQLErrors.forEach((error) => {
         // eslint-disable-next-line no-console
         console.error("Error in GraphQL", error);


### PR DESCRIPTION
Obtain the current user's profile from GraphQL, rather than REST. Update all the "profile id is number" assumptions to use strings. There are still plenty of numeric user ids, but not from the profile. E.g., the plan owner and ACL grants.

closes #226