### PR TITLE
remove all use of Recipe's favorite field in GraphQL

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -440,7 +440,6 @@ type Recipe implements Ingredient & Node & Owned {
     calories: Int
     directions: String
     externalUrl: String
-    favorite: Boolean!
     id: ID!
     ingredients(
         "Ingredient(s) to include. Missing/empty means \"all\"."

--- a/src/data/hooks/fragments.ts
+++ b/src/data/hooks/fragments.ts
@@ -43,7 +43,6 @@ fragment librarySearchResult on RecipeConnection {
         focus
       }
       name
-      favorite
       labels
       externalUrl
       calories

--- a/src/data/hooks/useGetFullRecipe.ts
+++ b/src/data/hooks/useGetFullRecipe.ts
@@ -13,7 +13,6 @@ query getRecipeWithEverything($id: ID!) {
   library {
     getRecipeById(id: $id) {
       ...recipeCore
-      favorite
       yield
       calories
       externalUrl

--- a/src/data/hooks/useUpdateRecipe.ts
+++ b/src/data/hooks/useUpdateRecipe.ts
@@ -9,7 +9,6 @@ mutation updateRecipe($id: ID!, $info: IngredientInfo!, $photo: Upload) {
   library {
     updateRecipe(id: $id, info: $info, photo: $photo) {
       ...recipeCore
-      favorite
       yield
       calories
       externalUrl

--- a/src/features/RecipeLibrary/types.ts
+++ b/src/features/RecipeLibrary/types.ts
@@ -5,7 +5,6 @@ export type RecipeCard = Pick<
     | "id"
     | "calories"
     | "externalUrl"
-    | "favorite"
     | "labels"
     | "name"
     | "photo"

--- a/src/global/types/types.ts
+++ b/src/global/types/types.ts
@@ -26,7 +26,6 @@ export interface Recipe extends Ingredient {
      */
     libraryRecipeId?: BfsId;
     ownerId?: BfsId;
-    favorite?: boolean;
 }
 
 export interface PantryItem extends Ingredient {


### PR DESCRIPTION
Recipe's `favorite` field isn't used, and it's poorly typed to leverage Apollo. Cull it.