### PR TITLE
Fav state

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,14 @@ export default [
             "no-restricted-imports": [
                 "error",
                 {
-                    paths: ["@mui/icons-material"],
+                    paths: [
+                        "@mui/icons-material",
+                        {
+                            name: "@apollo/client",
+                            importNames: ["gql"],
+                            message: "Import 'gql' from '@/__generated__'",
+                        },
+                    ],
                     patterns: ["@mui/icons-material/*"],
                 },
             ],

--- a/src/data/hooks/fragments.ts
+++ b/src/data/hooks/fragments.ts
@@ -1,4 +1,4 @@
-import { gql } from "@apollo/client";
+import { gql } from "@/__generated__";
 
 // Required for typed codegen, not imported directly into queries
 // noinspection JSUnusedLocalSymbols

--- a/src/features/Favorites/components/Indicator.tsx
+++ b/src/features/Favorites/components/Indicator.tsx
@@ -16,8 +16,7 @@ interface Props {
 const Indicator: React.FC<Props> = ({ type, id }) => {
     const removeFavorite = useRemoveFavorite(type);
     const markFavorite = useMarkFavorite(type);
-    const isFavorite = useIsFavorite();
-    const favorite = isFavorite(id);
+    const favorite = useIsFavorite(id);
 
     function handleClick(e) {
         e.stopPropagation();


### PR DESCRIPTION
Instead of indexing favorites per indicator, simply scan for the target object. Not great, but rather better!

Disallow importing `gql` from Apollo, as it carries no type info. The `gql` to use comes from codegen's output in `@/__generated__`.

Closes #225 