### PR TITLE
Create plan error

### DIFF
--- a/src/features/Planner/PlannerController.tsx
+++ b/src/features/Planner/PlannerController.tsx
@@ -60,13 +60,14 @@ type Props = RouteComponentProps<{
 
 export const PlannerController: React.FC<Props> = ({ match }) => {
     useLoadedPlan(match.params.pid);
-    const { data: allPlans, loading } = useGetAllPlans();
-    const state = useFluxStore(() => {
+    const { data: allPlans, loading: allLoading } = useGetAllPlans();
+    const { activeLoading, ...state } = useFluxStore(() => {
         const activePlan = planStore.getActivePlanRlo();
         const activeItem = planStore.getActiveItem();
         const selectedItems = planStore.getSelectedItems();
         return {
             activePlan,
+            activeLoading: activePlan.loading,
             planDetailVisible: planStore.isPlanDetailVisible(),
             itemTuples: activePlan.data ? listTheTree(activePlan.data.id) : [],
             isItemActive: activeItem
@@ -80,5 +81,11 @@ export const PlannerController: React.FC<Props> = ({ match }) => {
                 : () => false,
         };
     }, [planStore, LibraryStore]);
-    return <Plan loading={loading} allPlans={allPlans} {...state} />;
+    return (
+        <Plan
+            loading={activeLoading || allLoading}
+            allPlans={allPlans}
+            {...state}
+        />
+    );
 };

--- a/src/util/ripLoadObject.ts
+++ b/src/util/ripLoadObject.ts
@@ -8,8 +8,22 @@ export interface RippedLO<T> {
 }
 
 export function ripLoadObject<T>(lo: LoadObject<T>): RippedLO<T> {
+    if (import.meta.env.DEV) {
+        if (lo.isCreating()) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                "LoadObject.creating is deprecated. Use .loading (as Apollo does).",
+            );
+        }
+        if (lo.isUpdating()) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                "LoadObject.updating is deprecated. Use .loading (as Apollo does).",
+            );
+        }
+    }
     return {
-        loading: lo.isLoading(),
+        loading: lo.isLoading() || lo.isCreating() || lo.isUpdating(),
         deleting: lo.isDeleting(),
         data: lo.getValue() || undefined,
         error: lo.getError(),


### PR DESCRIPTION
Fix a couple weirdnesses during LoadObject and GraphQL migration which combined to create a race after creating a plan which resulted in an NPE trying to get the new plan's ACL before it had round-tripped the server.