### PR TITLE
fix colorHash to work on longer strings

### DIFF
--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -34,19 +34,15 @@ if (import.meta.env.DEV) {
     }
 }
 
+const tinyHash = (s) => {
+    // based on https://stackoverflow.com/a/52171480
+    let h = 9;
+    for (let i = 0; i < s.length; )
+        h = Math.imul(h ^ s.charCodeAt(i++), 9 ** 9);
+    return h ^ (h >>> 9);
+};
+
 export const colorHash = (id: BfsId) => {
-    let n = 0;
-    for (const codePoint of id.toString()) {
-        n *= 31;
-        n += codePoint.codePointAt(0) || 0;
-    }
-    const l = planColors.length;
-    let h = 0;
-    // This XORs all the bits of the number, instead of just the last few, which
-    // depends on the modulus being a power of two for a fair distribution.
-    while (n > 0) {
-        h ^= n % l;
-        n = Math.floor(n / l);
-    }
-    return planColors[h];
+    const h = Math.abs(tinyHash(id.toString()));
+    return planColors[h % planColors.length];
 };

--- a/src/features/UserProfile/components/Developer.tsx
+++ b/src/features/UserProfile/components/Developer.tsx
@@ -81,12 +81,9 @@ const DevMode: React.FC = () => {
 
     function handleResample() {
         const samples = planColors.map(() => 0);
+        let n = 27000 + Math.floor(Math.random() * 1000);
         for (let i = planColors.length * SAMPLES_PER_SWATCH; i > 0; i--) {
-            samples[
-                planColors.indexOf(
-                    colorHash(Math.random().toString().substring(2)),
-                )
-            ] += 1;
+            samples[planColors.indexOf(colorHash("87777497" + n++))] += 1;
         }
         setSamples(samples);
     }


### PR DESCRIPTION
JS doesn't have integer overflow, just floating point truncation, which led to excessive collisions on longer strings which differed only in their final characters. It was especially pronounced where the current ID generator happened to be on my local, but had inappropriate bias anywhere the hash value grew past `Number.MAX_SAFE_INTEGER`.