### PR TITLE
sx breakpoints are "up"; fix ones converted from the .down helper

### DIFF
--- a/src/features/RecipeDisplay/components/RecipeDetail.tsx
+++ b/src/features/RecipeDisplay/components/RecipeDetail.tsx
@@ -78,9 +78,7 @@ const RecipeDetail: React.FC<Props> = ({
             <SubHeader>
                 <Toolbar
                     sx={(theme) => ({
-                        flexWrap: {
-                            sm: "wrap-reverse",
-                        },
+                        flexWrap: ["wrap-reverse", "unset"],
                         backgroundColor: theme.palette.background.paper,
                         padding: 0,
                     })}
@@ -92,9 +90,7 @@ const RecipeDetail: React.FC<Props> = ({
                         variant="h2"
                         sx={{
                             flexGrow: 1,
-                            width: {
-                                sm: "100%",
-                            },
+                            width: ["100%", "unset"],
                         }}
                     >
                         {recipe.name}

--- a/src/views/common/SnackPack.tsx
+++ b/src/views/common/SnackPack.tsx
@@ -98,11 +98,7 @@ function SnackPack() {
             autoHideDuration={messageInfo.hideDelay || 5000}
             onClose={handleClose}
             message={message}
-            sx={{
-                bottom: {
-                    sm: fabVisible ? 90 : 0,
-                },
-            }}
+            sx={fabVisible ? { bottom: [90, 0] } : undefined}
             action={
                 <>
                     {messageInfo.renderAction


### PR DESCRIPTION
When `makeStyles` was removed last fall, the embedded media queries had their orientation "flipped" because of how the `sx` prop works. Flip them back around.

closes #244 