### PR TITLE
Bulk create buckets

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "prestart": "npm run compile",
     "start": "vite",
     "prebuild": "npm run compile",
-    "build": "tsc && vite build",
+    "build": "tsc --noEmit && vite build",
     "min-xml": "minify-xml --verbose --in-place",
     "postbuild": "npm run min-xml -- --no-collapse-empty-elements build/index.html",
     "compile": "graphql-codegen",

--- a/schema.graphql
+++ b/schema.graphql
@@ -387,6 +387,8 @@ type PlannerMutation {
     assignBucket(bucketId: ID, id: ID!): PlanItem!
     "Create a new bucket w/in a plan, with an optional name and date."
     createBucket(date: Date, name: String, planId: ID!): PlanBucket!
+    "Create multiple new buckets w/in a plan."
+    createBuckets(buckets: [UnsavedBucket!]!, planId: ID!): [PlanBucket!]!
     """
 
     Create a new item under the specified parent (which may be a plan, for
@@ -684,4 +686,9 @@ input IngredientRefInfo {
     raw: String!
     units: String
     uomId: Long
+}
+
+input UnsavedBucket {
+    date: Date
+    name: String
 }

--- a/src/features/Planner/data/mutations.ts
+++ b/src/features/Planner/data/mutations.ts
@@ -67,10 +67,17 @@ mutation deleteBucket($planId: ID!, $bucketId: ID!) {
   }
 }`);
 
-export const DELETE_BUCKETS = gql(`
-mutation deleteBuckets($planId: ID!, $bucketIds: [ID!]!) {
+export const SPLICE_BUCKETS = gql(`
+mutation spliceBuckets($planId: ID!, $idsToDelete: [ID!]!, $toCreate: [UnsavedBucket!]!) {
   planner {
-    deleteBuckets(planId: $planId, bucketIds: $bucketIds) { id }
+    deleteBuckets(planId: $planId, bucketIds: $idsToDelete) {
+      id
+    }
+    createBuckets(planId: $planId, buckets: $toCreate) {
+      id
+      name
+      date
+    }
   }
 }`);
 

--- a/src/features/Planner/data/utils.ts
+++ b/src/features/Planner/data/utils.ts
@@ -1001,16 +1001,16 @@ export function resetToThisWeeksBuckets(state: State, planId: BfsId): State {
             }
             result.push(b);
         }
-        if (toDelete.length > 0) {
-            PlanApi.deleteBuckets(planId, toDelete);
-        }
+        const toCreate: PlanBucket[] = [];
         for (const d of desiredDates) {
-            const b = {
+            toCreate.push({
                 id: ClientId.next(),
                 date: new Date(d),
-            };
-            saveBucket(state, b);
-            result.push(b);
+            });
+        }
+        if (toDelete.length > 0 || toCreate.length > 0) {
+            PlanApi.spliceBuckets(planId, toDelete, toCreate);
+            result.push(...toCreate);
         }
         return result.sort(bucketComparator);
     });

--- a/src/util/promiseFlux.ts
+++ b/src/util/promiseFlux.ts
@@ -75,6 +75,15 @@ const informUserOfPromiseError = () => {
     }
 };
 
+export const defaultErrorHandler = (error) => {
+    // eslint-disable-next-line no-console
+    console.error("Error in Promise", error);
+    if (!isAuthError(error) || !askUserToReauth()) {
+        informUserOfPromiseError();
+    }
+    return fallthrough(error);
+};
+
 /**
  * I adapt Promises (which are gross) to Flux actions (which are sexy). The
  * resolve and reject params define what to do when the Promise settles, and can
@@ -99,14 +108,7 @@ const informUserOfPromiseError = () => {
 function promiseFlux<Data>(
     promise: Promise<Data>,
     resolver: TypeTemplateOrCallback<Data>,
-    rejector: TypeTemplateOrCallback<unknown> = (error) => {
-        // eslint-disable-next-line no-console
-        console.error("Error in Promise", error);
-        if (!isAuthError(error) || !askUserToReauth()) {
-            informUserOfPromiseError();
-        }
-        return fallthrough(error);
-    },
+    rejector: TypeTemplateOrCallback<unknown> = defaultErrorHandler,
 ) {
     return promise.then(helper("data", resolver), helper("error", rejector));
 }


### PR DESCRIPTION
When resetting a plan's buckets to "this week", issue a single GraphQL request to perform the needed deletes and creates in a single call.