### PR TITLE
if the old CRA service worker loads, unregister everything

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,6 @@
+// This is where the old CRA service worker lived. If it's requested, unregister
+// everything, so the Vite one (at sw.js) can take over control.
+if ("serviceWorker" in navigator)
+    navigator.serviceWorker.getRegistrations()
+        .then(rs => rs
+            .forEach(r => r.unregister()));


### PR DESCRIPTION
The old CRA service worker blocks the new Vite service worker from controlling the page, even though the latter gets successfully registered. Reinstate the CRA one with "unregister all service workers" behavior. On next load of the app, it'll refresh the worker, and unregister itself. On the following load, Vite's worker will be re-registered.