### PR TITLE
Graphql cleanups

### DIFF
--- a/src/GoBrennas.scss
+++ b/src/GoBrennas.scss
@@ -166,3 +166,7 @@ body {
         }
     }
 }
+
+.MuiImageListItem-img {
+    overflow: hidden;
+}

--- a/src/data/utils/graphql.ts
+++ b/src/data/utils/graphql.ts
@@ -5,7 +5,8 @@ import { toMilliseconds } from "@/util/time";
 
 const mapIngRef = (it: IngredientRef): IngredientRefInfo => {
     it = { ...it };
-    delete it.id;
+    delete it.id; // this is a client-only concept - refs have no identity.
+    delete it.ingredient; // the dereferenced ingredientId, for rendering.
     return it as IngredientRefInfo;
 };
 

--- a/src/global/types/types.ts
+++ b/src/global/types/types.ts
@@ -53,9 +53,11 @@ export interface IngredientRef<I = Ingredient> {
     preparation?: string | null;
     units?: string | null;
     uomId?: Maybe<BfsId>;
+    /**
+     * This is 'I' in read contexts and 'string' in write ones. More or less.
+     */
     ingredient?: I | string | null;
     ingredientId?: Maybe<BfsId>;
-
     /**
      * On the shopping list, napalm entries will only have name, not raw.
      */


### PR DESCRIPTION
With Spring GraphQL will come caching of parsed queries, so properly variable-ize the poll-for-updates query. The structure still varies based on how many plans are active on the client, but no longer which plans.

Also suppress sending full ingredients with saving recipes, and hide image overflow on the textract browser.